### PR TITLE
Backup in the sharded setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,32 @@
-language: java
 sudo: required
 dist: trusty
 services:
-- docker
+  - docker
+
+language: java
+jdk: oraclejdk8
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
-  - "$HOME/.gradle"
-matrix:
-  include:
-  - os: linux
-    jdk: oraclejdk8
-    env:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+env:
+  global:
     - DOCKER_USER=xenitpublisher
     - secure: "RDtHqrRZ+pA66IXCZf2j/MxEp9ZtpoWBdBlNf8gyGETL/d2HpOZVR5OqKRG8udgzbcFbEOXil1NdbXg9Yt3G5K4g22B3M5++f4i+AyaKoXq6+XRFA7bTtRfQa7NqOaUCP8ThqSR1yf9mbm1RfttywrmIDJrf3QzbVNKwZ473tyxk4Bj+4CYcANBS0a43fYy7I0m4g3f0Chgm3KlyMEOc5nwLs5pIVQHPbIh8O66JnHn0g5TRG1QCxOnjTXzKQIUyVd9O4Cl3z7MANwud6+4skp3Qoshnyf0EujAxW/E5jRd/FvjYr+Hc4c4naGq1zHWBO/TaNN5ze2f+rvhwU7u7LGKDCJmFpRpvzM4i3ENd0kLck0l/Q/XXcutl2+ZE6Esv/pUGLhhV2K+xT+7L4LyzxdaP60eyA41fpmwTeByYiCwAIqxPhV7H3bS905aaL2uZssJm8Lq5DgC7F1YvCE/EgySz9Wc0hBMxRFHm8bTqlXrUG5YnFu1GV18LYUk6iJb5dO6ZBLenOOq58pic2YYjhD7CEosmNlvntAhv08dnOyhYtSV5sW2aCQTEYBs1nmyXh0CPUiaenfKb0LO0UWsLCDe8Rdg7aEXCgyku8XlOU2rQUlY0Dgweb10Smxqm9qPxZLiUZodNo1f1FW3ea24LJtUcytw9lkEddPqfPiPnXp8="
-    before_install:
-    - chmod +x ./gradlew
-    script:
-    - if [[ $TRAVIS_BRANCH = "master" ]] ; then ./gradlew -PrepoName=xeniteu integrationTests pushDockerImage ; else ./gradlew -PrepoName=xeniteu integrationTests --info ; fi
+  matrix:
+    - VERSIONS_TO_BUILD=solr1
+    - VERSIONS_TO_BUILD=solr4
+    - VERSIONS_TO_BUILD=solr6
+
+script: ./gradlew -PrepoName=xeniteu integrationTests --info
+
+deploy:
+  provider: script
+  script: ./gradlew -PrepoName=xeniteu pushDockerImage
+  on:
+    branch: master

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 * [DOCKER-248] Make sure backup folders exist in the case of a sharded setup. Backup needs to be triggered manually
-* [DOCKER-248] For solr1 and solr6 default backup locations are: /opt/alfresco/alf_data/solrBackup and /opt/alfresco/alf_data/solr4Backup
+* [DOCKER-248] Default backup locations are: /opt/alfresco/alf_data/solrBackup, /opt/alfresco/alf_data/solr4Backup, /opt/alfresco-search-services/data/solr6Backup
 
 ## [v1.0.0] - 2019-07-15 Move to github
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+* [DOCKER-248] Make sure backup folders exist in the case of a sharded setup. Backup needs to be triggered manually
+* [DOCKER-248] For solr1 and solr6 default backup locations are: /opt/alfresco/alf_data/solrBackup and /opt/alfresco/alf_data/solr4Backup
+
 ## [v1.0.0] - 2019-07-15 Move to github
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ To see all available tasks:
 
 If you have access to [Alfresco private repository](https://artifacts.alfresco.com/nexus/content/groups/private/) add the repository to build.gradle and add -Penterprise to your build command.
 
+## Solr backup
+
+In the case of a non-sharded setup, solr index is backed-up via a scheduled job in Alfresco. 
+Parameters for the backup (location, maximum number of backups to keep) are set on Alfresco's side and passed to solr via the scheduled job, which calls the replication handler from solr.
+By default they are /opt/alfresco/alf_data/solrBackup for solr1, /opt/alfresco/alf_data/solr4Backup for solr4 and /opt/alfresco-search-services/data/solr6Backup for solr6.
+
+In the case of a sharded setup, backup needs to be done manually.
 
 ## FAQ
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,10 +10,16 @@
 
 rootProject.name = 'docker-solr'
 
-include 'solr6/alfresco-search-services-community-1.3.0.1'
-include 'solr4/community-5.2'
-include 'solr4/community-5.1'
-include 'solr1/community-4.2'
+if(System.getenv("VERSIONS_TO_BUILD")==null || System.getenv("VERSIONS_TO_BUILD").equals("solr6")) {
+    include 'solr6/alfresco-search-services-community-1.3.0.1'
+}
+if(System.getenv("VERSIONS_TO_BUILD")==null || System.getenv("VERSIONS_TO_BUILD").equals("solr4")) {
+    include 'solr4/community-5.2'
+    include 'solr4/community-5.1'
+}
+if(System.getenv("VERSIONS_TO_BUILD")==null || System.getenv("VERSIONS_TO_BUILD").equals("solr1")) {
+    include 'solr1/community-4.2'
+}
 
 // test also against enterprise versions of Alfresco
 if(hasProperty("enterprise")) {

--- a/solr1/local/92-init-solr.sh
+++ b/solr1/local/92-init-solr.sh
@@ -175,10 +175,10 @@ echo "export JAVA_OPTS" >> $TOMCAT_CONFIG_FILE
 
 user="tomcat"
 # make sure backup folders exist and have the right permissions in case of mounts
-if [[ ! -d "${DIR_ROOT}/solr4Backup" ]]
+if [[ ! -d "${DIR_ROOT}/solrBackup" ]]
 then
-    mkdir -p "${DIR_ROOT}/solr4Backup/alfresco" "${DIR_ROOT}/solr4Backup/archive"
-	chown -hR "$user":"$user" "${DIR_ROOT}/solr4Backup"
+    mkdir -p "${DIR_ROOT}/solrBackup/alfresco" "${DIR_ROOT}/solrBackup/archive"
+	chown -hR "$user":"$user" "${DIR_ROOT}/solrBackup"
 fi
 # fix permissions for whole data folder in case of mounts
 if [[ $(stat -c %U /opt/alfresco/alf_data) != "$user" ]]

--- a/solr1/local/92-init-solr.sh
+++ b/solr1/local/92-init-solr.sh
@@ -9,6 +9,7 @@ set -e
 echo "Solr init start"
 
 SOLR_DATA_ROOT=${SOLR_DATA_ROOT:-'/opt/alfresco/alf_data/solr4'}
+DIR_ROOT=${DIR_ROOT:-'/opt/alfresco/alf_data'}
 
 JAVA_XMS=${JAVA_XMS:-'512M'}
 JAVA_XMX=${JAVA_XMX:-'2048M'}
@@ -174,10 +175,10 @@ echo "export JAVA_OPTS" >> $TOMCAT_CONFIG_FILE
 
 user="tomcat"
 # make sure backup folders exist and have the right permissions in case of mounts
-if [[ ! -d "${SOLR_DATA_ROOT}/solr4Backup" ]]
+if [[ ! -d "${DIR_ROOT}/solr4Backup" ]]
 then
-    mkdir -p "${SOLR_DATA_ROOT}/solr4Backup/alfresco" "${SOLR_DATA_ROOT}/solr4Backup/alfresco"
-	chown -hR "$user":"$user" "${SOLR_DATA_ROOT}/solr4Backup"
+    mkdir -p "${DIR_ROOT}/solr4Backup/alfresco" "${DIR_ROOT}/solr4Backup/archive"
+	chown -hR "$user":"$user" "${DIR_ROOT}/solr4Backup"
 fi
 # fix permissions for whole data folder in case of mounts
 if [[ $(stat -c %U /opt/alfresco/alf_data) != "$user" ]]

--- a/solr6/local/92-init-solr.sh
+++ b/solr6/local/92-init-solr.sh
@@ -345,11 +345,28 @@ makeConfigs
 
 user="solr"
 # make sure backup folders exist and have the right permissions in case of mounts
-if [[ ! -d "${SOLR_DATA_ROOT}/solr6Backup" ]] || [[ $(stat -c %U "${SOLR_DATA_ROOT}/solr6Backup") != "$user" ]]
+if [ $SHARDING = true ]
 then
-    mkdir -p "${SOLR_DATA_ROOT}/solr6Backup/alfresco"  "${SOLR_DATA_ROOT}/solr6Backup/archive"
-	chown -hR "$user":"$user" "${SOLR_DATA_ROOT}/solr6Backup"
+  for i in $(echo $SHARD_IDS | tr "," "\n")
+  do
+	  solrCoreName=alfresco-$i
+	  mkdir -p "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName"
+	  if [[ $(stat -c %U "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName") != "$user" ]]
+	  then
+	    chown -hR "$user":"$user" "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName"
+	  fi
+  done
+else
+  for solrCoreName in alfresco archive
+  do
+      mkdir -p "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName"
+      if [[ $(stat -c %U "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName") != "$user" ]]
+	  then
+	    chown -hR "$user":"$user" "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName"
+	  fi
+  done
 fi
+
 # fix permissions for whole data folder in case of mounts
 if [[ $(stat -c %U "${SOLR_DATA_ROOT}") != "$user" ]]
 then

--- a/solr6/local/92-init-solr.sh
+++ b/solr6/local/92-init-solr.sh
@@ -9,7 +9,9 @@ echo "Solr init start"
 
 SOLR_DIR_ROOT="$SOLR_INSTALL_HOME/solrhome"
 SOLR_DATA_ROOT="$SOLR_INSTALL_HOME/data"
+DIR_ROOT=${DIR_ROOT:-'/opt/alfresco-search-services/data'}
 SOLR_HOST=${SOLR_HOST:-'localhost'}
+
 
 DEBUG=${DEBUG:-'false'}
 ALFRESCO_SSL=${ALFRESCO_SSL:-'https'}
@@ -350,19 +352,19 @@ then
   for i in $(echo $SHARD_IDS | tr "," "\n")
   do
 	  solrCoreName=alfresco-$i
-	  mkdir -p "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName"
-	  if [[ $(stat -c %U "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName") != "$user" ]]
+	  mkdir -p "${DIR_ROOT}/solr6Backup/$solrCoreName"
+	  if [[ $(stat -c %U "${DIR_ROOT}/solr6Backup/$solrCoreName") != "$user" ]]
 	  then
-	    chown -hR "$user":"$user" "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName"
+	    chown -hR "$user":"$user" "${DIR_ROOT}/solr6Backup/$solrCoreName"
 	  fi
   done
 else
   for solrCoreName in alfresco archive
   do
-      mkdir -p "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName"
-      if [[ $(stat -c %U "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName") != "$user" ]]
+      mkdir -p "${DIR_ROOT}/solr6Backup/$solrCoreName"
+      if [[ $(stat -c %U "${DIR_ROOT}/solr6Backup/$solrCoreName") != "$user" ]]
 	  then
-	    chown -hR "$user":"$user" "${SOLR_DATA_ROOT}/solr6Backup/$solrCoreName"
+	    chown -hR "$user":"$user" "${DIR_ROOT}/solr6Backup/$solrCoreName"
 	  fi
   done
 fi


### PR DESCRIPTION
Make sure default locations for the backup of sharded setup exist.
Backup needs to be called manually, there is no scheduled job for the sharded setup.

Correct backup location in the case of solr1 and solr4.