### PR TITLE
Remove duplicated logic from solr's init script

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* [DOCKER-251] Remove from solr's init duplicating logic related to JAVA_OPTS_ variables
+	
 ### Changed
 * [DOCKER-248] Make sure backup folders exist in the case of a sharded setup. Backup needs to be triggered manually
 * [DOCKER-248] Default backup locations are: /opt/alfresco/alf_data/solrBackup, /opt/alfresco/alf_data/solr4Backup, /opt/alfresco-search-services/data/solr6Backup

--- a/solr1/local/92-init-solr.sh
+++ b/solr1/local/92-init-solr.sh
@@ -42,19 +42,6 @@ function setJavaOption {
     JAVA_OPTS="$JAVA_OPTS $2"
 }
 
-function setJavaOptions {
-    IFS=$'\n'
-    for i in `env`
-    do
-	if [[ $i == JAVA_OPTS_* ]]
-	    then
-	    key=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 3-`
-	    value=`echo $i | cut -d '=' -f 2-`
-	    setJavaOption $key $value
-	fi
-    done
-}
-
 function setOption {
     if grep --quiet -e "$1\s*=" "$3"; then
         # replace option
@@ -162,8 +149,6 @@ then
     # be sure port 5000 is mapped on the host also on 5000
     setJavaOption "jmx" "-Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.rmi.port=5000 -Dcom.sun.management.jmxremote.port=5000 -Djava.rmi.server.hostname=${JMX_RMI_HOST}"
 fi
-
-setJavaOptions
 
 setJavaOption 'SSL_TRUST_STORE' "-DSSL_TRUST_STORE=${SSL_TRUST_STORE:-'ssl.truststore'}"
 setJavaOption 'SSL_TRUST_STORE_PASSWORD' "-DSSL_TRUST_STORE_PASSWORD=${SSL_TRUST_STORE_PASSWORD:-'kT9X6oe68t'}"

--- a/solr4/local/92-init-solr.sh
+++ b/solr4/local/92-init-solr.sh
@@ -41,19 +41,6 @@ function setJavaOption {
     JAVA_OPTS="$JAVA_OPTS $2"
 }
 
-function setJavaOptions {
-    IFS=$'\n'
-    for i in `env`
-    do
-	if [[ $i == JAVA_OPTS_* ]]
-	    then
-	    key=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 3-`
-	    value=`echo $i | cut -d '=' -f 2-`
-	    setJavaOption $key $value
-	fi
-    done
-}
-
 function setOption {
     if grep --quiet -e "$1\s*=" "$3"; then
         # replace option
@@ -211,8 +198,6 @@ then
     # be sure port 5000 is mapped on the host also on 5000
     setJavaOption "jmx" "-Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.rmi.port=5000 -Dcom.sun.management.jmxremote.port=5000 -Djava.rmi.server.hostname=${JMX_RMI_HOST}"
 fi
-
-setJavaOptions
 
 ### DEPRECATED
 # for backwards compatibility with ansible-role-solr we keep the old options as well

--- a/solr6/local/92-init-solr.sh
+++ b/solr6/local/92-init-solr.sh
@@ -59,19 +59,6 @@ function setJavaOption {
     JAVA_OPTS="$JAVA_OPTS $2"
 }
 
-function setJavaOptions {
-    IFS=$'\n'
-    for i in `env`
-    do
-	if [[ $i == JAVA_OPTS_* ]]
-	    then
-	    key=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 3-`
-	    value=`echo $i | cut -d '=' -f 2-`
-	    setJavaOption $key $value
-	fi
-    done
-}
-
 function setOption {
     if grep --quiet -e "$1\s*=" "$3"; then
         # replace option
@@ -342,7 +329,6 @@ fi
 # make sure there is an option in JAVA_OPTS, otherwise it throws an error
 JAVA_OPTS="${JAVA_OPTS} -Ddummy=true"
 
-setJavaOptions
 makeConfigs
 
 user="solr"

--- a/solr6/local/92-init-solr.sh
+++ b/solr6/local/92-init-solr.sh
@@ -291,12 +291,7 @@ function makeConfigs {
 
 if [ $DEBUG = true ]
 then
-    if [[ $ALFRESCO_SEARCH_SERVICES_VERSION = "1.0"* ]] ||  [[ $ALFRESCO_SEARCH_SERVICES_VERSION = "1.1"* ]] || [[ $ALFRESCO_SEARCH_SERVICES_VERSION = "1.2"* ]]
-    then
-    setJavaOption "debug" "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000"
-    else
-    setJavaOption "debug" "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000"
-    fi
+    setJavaOption "debug" "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8000"
 fi
 if [ $JMX_ENABLED = true ]
 then


### PR DESCRIPTION
Java opts variables can be set via environment variables of the form JAVA_OPTS_<variable>.
Currently the logic to do that is duplicated in the init script of the base java image and of the solr's init script.
Removing it from solr.