### PR TITLE
[DOCKER-285] Add quotes around $JAVA_OPTS before passing it to solr start

### DIFF
--- a/solr6/local/92-init-solr.sh
+++ b/solr6/local/92-init-solr.sh
@@ -344,6 +344,6 @@ fi
 # fix permissions for config folders
 chown -R "$user":"$user" "${SOLR_DIR_ROOT}"
 
-echo "exec gosu ${user} ${SOLR_INSTALL_HOME}/solr/bin/solr start -f -m ${JAVA_XMX} -p ${PORT} -h ${SOLR_HOST} -s ${SOLR_DIR_ROOT} -a ${JAVA_OPTS}" >"${SOLR_INSTALL_HOME}/startup.sh"
+echo "exec gosu ${user} ${SOLR_INSTALL_HOME}/solr/bin/solr start -f -m ${JAVA_XMX} -p ${PORT} -h ${SOLR_HOST} -s ${SOLR_DIR_ROOT} -a \"${JAVA_OPTS}\"" >"${SOLR_INSTALL_HOME}/startup.sh"
 
 echo "Solr init done"


### PR DESCRIPTION
Without quotes, it only works when the variable does not contain any
spaces, so only when max 1 option is being passed to Java.

Fixes #18