### PR TITLE
More generic shard handling

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,7 +5,7 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ master ]
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
 
@@ -38,5 +38,7 @@ jobs:
        VERSIONS_TO_BUILD: ${{ matrix.version }}      
        DOCKER_USER: ${{ secrets.DOCKER_USER }}
        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      if: contains(github.ref, 'master')
       run: ./gradlew -PrepoName=docker.io/xenit pushDockerImage      
+
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,14 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v1.0.1] - 2020-05-14 Refactorings for sharded setup
 ### Added
-* [DOCKER-264] Alfresco-search-services-1.3.0.6	
+* [DOCKER-264] Alfresco-search-services-1.3.0.6
 	
 ### Fixed
 * [DOCKER-251] Remove from solr's init duplicating logic related to JAVA_OPTS_ variables
 	
 ### Changed
+* [DOCKER-332] Simplified sharding code	
 * [DOCKER-278] Move Java specific variables to java layer
 * [DOCKER-261], [DOCKER-259], [DOCKER-257] Refactorings, notifications	
 * [DOCKER-248] Make sure backup folders exist in the case of a sharded setup. Backup needs to be triggered manually

--- a/README.md
+++ b/README.md
@@ -47,17 +47,9 @@ See also environment variables from lower layers: [`docker-openjdk`](https://git
 
 | Variable                    | solrcore.property variable | java variable                                                | Default                                                      | Comments |
 | --------------------------- | --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | --------------------------- |
-| SHARDING                    |                      |                                                              | false                                               | if true, configuration folders for shards will be created |
-| NUM_SHARDS                  | shard.count / acl.shard.count |                                                              | 3 | solr6 / solr4 |
-| NUM_NODES           |                  |                                                              | 2                                                        |  |
-| NODE_INSTANCE                  |                         |                                                              | 1                                                   |  |
 | TEMPLATE                  | alfresco.template |                                                              | rerank                                                   |  |
-| REPLICATION_FACTOR              |                     |                                                              | 1                                                        |  |
-| SHARD_IDS                   | shard.instance / acl.shard.instance |                                                              | 0,1                                     | loop over values to create config folders \\ solr6 / solr4 |
-| SHARD_METHOD | shard.method | | DB_ID | solr6 only |
-| SHARD_KEY | shard.key | | cm:creator | solr6 only, used when SHARD_METHOD=PROPERTY |
-| SHARD_RANGE | shard.range | | 0-100000 | solr6 only, used when SHARD_METHOD=DB_ID_RANGE |
 | CORES_TO_TRACK | | | alfresco;archive | loop over values to create config folders \\ solr6 only |
+| CORES_ALFRESCO | | | alfresco | in case of sharded setups, cores to be created on the current host \\ solr6 only |
 | SOLR_DATA_DIR | | | /opt/alfresco-search-services/data/index | solr6 only |
 | SOLR_MODEL_DIR | | | /opt/alfresco-search-services/data/model | solr6 only |
 | SOLR_CONTENT_DIR | | | /opt/alfresco-search-services/data/contentstore | solr6 only |
@@ -77,7 +69,8 @@ See also environment variables from lower layers: [`docker-openjdk`](https://git
 | JETTY_PORT_SSL | |  | 8443 | solr6 only |
 | GLOBAL_WORKSPACE_\<variable\> | \<variable\> | | | for workspace core or shards |
 | GLOBAL_ARCHIVE_\<variable\> | \<variable\> | | | for archive core |
-| GLOBAL_\<variable\> | \<variable> | | |  |
+| GLOBAL_ALL_\<variable\> | \<variable> | | | for all cores |
+| GLOBAL_<core>_\<variable\> | \<variable> | | | for specific core |
 | \* SSL_KEY_STORE | | | ssl.repo.client.keystore for solr6, ssl.keystore for solr4|  |
 | \* SSL_KEY_STORE_PASSWORD' | | | kT9X6oe68t | |
 | \* SSL_TRUST_STORE | | | ssl.repo.client.truststore for solr6, ssl.truststore for solr4 | |

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ See also environment variables from lower layers: [`docker-openjdk`](https://git
 | Variable                    | solrcore.property variable | java variable                                                | Default                                                      | Comments |
 | --------------------------- | --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | --------------------------- |
 | TEMPLATE                  | alfresco.template |                                                              | rerank                                                   |  |
-| CORES_TO_TRACK | | | alfresco;archive | loop over values to create config folders \\ solr6 only |
-| CORES_ALFRESCO | | | alfresco | in case of sharded setups, cores to be created on the current host \\ solr6 only |
+| CORES_TO_TRACK | | | alfresco;archive | loop over values to create config folders <br> solr6 only |
+| CORES_ALFRESCO | | | alfresco | in case of sharded setups, cores to be created on the current host, separated by ";" <br> Example: alfresco-01;alfresco-02 <br> Leave default for non-sharded setup <br> solr6 only |
 | SOLR_DATA_DIR | | | /opt/alfresco-search-services/data/index | solr6 only |
 | SOLR_MODEL_DIR | | | /opt/alfresco-search-services/data/model | solr6 only |
 | SOLR_CONTENT_DIR | | | /opt/alfresco-search-services/data/contentstore | solr6 only |

--- a/solr4/enterprise-5.1/overload.gradle
+++ b/solr4/enterprise-5.1/overload.gradle
@@ -10,7 +10,6 @@ ext {
     alfrescoimage ='hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:5.1.5'
     license='./license51'
     tests = true
-    testsSharded = true
 }
 dependencies {
     runtime group: 'org.alfresco', name: 'alfresco-solr4-distribution', version: '5.1.5', ext: 'zip'

--- a/solr6/local/92-init-solr.sh
+++ b/solr6/local/92-init-solr.sh
@@ -14,13 +14,10 @@ SOLR_HOST=${SOLR_HOST:-'solr'}
 CORES_TO_TRACK=${CORES_TO_TRACK:-"alfresco;archive"}
 IFS=';' read -r -a DEFAULT_CORES <<< "$CORES_TO_TRACK"
 
-SHARDING=${SHARDING:-'false'}
-NUM_SHARDS=${NUM_SHARDS:-'3'}
-NUM_NODES=${NUM_NODES:-'2'}
-NODE_INSTANCE=${NODE_INSTANCE:-'1'}
+CORES_ALFRESCO=${CORES_ALFRESCO:-"alfresco"}
+IFS=';' read -r -a DEFAULT_CORES_ALFRESCO <<< "$CORES_ALFRESCO"
+
 TEMPLATE=${TEMPLATE:-'rerank'}
-REPLICATION_FACTOR=${REPLICATION_FACTOR:-'1'}
-SHARD_IDS=${SHARD_IDS:-'0,1'}
 
 ALFRESCO_SOLR_SUGGESTER_ENABLED=${ALFRESCO_SOLR_SUGGESTER_ENABLED:-'true'}
 ALFRESCO_SOLR_FACETABLE_CATEGORIES_ENABLED=${ALFRESCO_SOLR_FACETABLE_CATEGORIES_ENABLED:-'false'}
@@ -57,34 +54,22 @@ function setOption {
     fi
 }
 
+# Options starting with GLOBAL_ALL_xxx are valid for all cores
+# Options starting with GLOBAL_<core>_xxx are valid for core=<core>
+# Options starting with GLOBAL_WORKSPACE_xxx are valid for any core containing alfresco (from man bash: the string  to  the  right  of  the operator  is considered an extended regular expression and matched accordingly (as in regex(3)))
 function setGlobalOptions {
     file=$1
     coreName=$2
     IFS=$'\n'
     for i in `env`
     do
-	if [[ $i == GLOBAL_WORKSPACE_* ]]
-	then
-	    if [ $coreName = alfresco ]
-	    then
-	        key=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 3-`
-	        value=`echo $i | cut -d '=' -f 2-`
-	        setOption $key $value "$file"
-	    fi
-	elif [[ $i == GLOBAL_ARCHIVE_* ]]
-	then
-	    if [ $coreName = archive ]
-	    then
-	        key=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 3-`
-	        value=`echo $i | cut -d '=' -f 2-`
-	        setOption $key $value "$file"
-	    fi
-	elif [[ $i == GLOBAL_* ]]
-	then
-            key=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 2-`
-            value=`echo $i | cut -d '=' -f 2-`
-            setOption $key $value "$file"
-	fi
+      envCoreName=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 2`
+      if [[ $envCoreName = $coreName ]] || [[ $envCoreName = "ALL" ]] || [[ $envCoreName = "WORKSPACE" && $coreName =~ alfresco ]]
+      then
+         key=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 3-`
+         value=`echo $i | cut -d '=' -f 2-`
+         setOption $key $value "$file"
+      fi
     done
 }
 
@@ -94,17 +79,16 @@ function escapeFile {
 
 function createCoreStatically {
     coreName="$1"
-    solrCoreName="$2"
-    newCore="$3"
+    newCore="$2"
 
-    echo "Creating Alfresco core=$coreName, solrCore=$solrCoreName in $newCore"
+    echo "Creating Alfresco core=$coreName in $newCore"
     CONFIG_FILE_CORE=$newCore/conf/solrcore.properties
     if [ ! -d  "$newCore" ]
     then
         cp -r ${SOLR_DIR_ROOT}/templates/$TEMPLATE $newCore
         FILE_CORE=$newCore/core.properties
         touch $FILE_CORE
-        setOption 'name' "$solrCoreName" "$FILE_CORE"
+        setOption 'name' "$coreName" "$FILE_CORE"
     fi
     setOption 'data.dir.root' "${SOLR_DATA_DIR:-$SOLR_DATA_ROOT/index}" "$CONFIG_FILE_CORE"
     setOption 'data.dir.store' "$coreName" "$CONFIG_FILE_CORE"
@@ -135,110 +119,59 @@ function makeConfigs {
 
 	if [ $coreName = alfresco ]
 	then
-	    # for sharding - dynamic registration of shards
-	    if [ $SHARDING = true ]
-	    then
-            # assuming we shard the workspace store
-            rm -rf ${SOLR_DIR_ROOT}/workspace-SpacesStore
-            collectionName=${TEMPLATE}--workspace-SpacesStore--shards--$NUM_SHARDS-x-$REPLICATION_FACTOR--node--$NODE_INSTANCE-of-$NUM_NODES
-            echo "collectionName=$collectionName for SHARD_IDS=$SHARD_IDS"
-            mkdir -p ${SOLR_DIR_ROOT}/$collectionName
-            for i in $(echo $SHARD_IDS | tr "," "\n")
-            do
-                coreName=workspace-SpacesStore-$i
-                solrCoreName=alfresco-$i
-                newCore=${SOLR_DIR_ROOT}/$collectionName/$coreName
-                CONFIG_FILE_CORE=$newCore/conf/solrcore.properties
+          for coreAlfrescoName in "${DEFAULT_CORES_ALFRESCO[@]}"
+	  do
+             # only use a collection in the case of a real sharded setup
+             if [ $coreAlfrescoName != $coreName ]
+	     then
+		 collectionName=${TEMPLATE}-alfresco
+		 mkdir -p ${SOLR_DIR_ROOT}/$collectionName
+		 newCore=${SOLR_DIR_ROOT}/$collectionName/$coreAlfrescoName
+	     fi
 
-                createCoreStatically "$coreName" "$solrCoreName" "$newCore"
+             CONFIG_FILE_CORE=$newCore/conf/solrcore.properties
 
-                setOption 'enable.alfresco.tracking' "${ALFRESCO_ENABLE_TRACKING:-true}" "$CONFIG_FILE_CORE"
-                setOption 'alfresco.index.transformContent' "${ALFRESCO_INDEX_CONTENT:-true}" "$CONFIG_FILE_CORE"
-                setOption 'alfresco.corePoolSize' "${ALFRESCO_CORE_POOL_SIZE:-8}" "$CONFIG_FILE_CORE"
-                setOption 'alfresco.doPermissionChecks' "${ALFRESCO_DO_PERMISSION_CHECKS:-true}" "$CONFIG_FILE_CORE"
-                setOption 'solr.suggester.enabled' "$ALFRESCO_SOLR_SUGGESTER_ENABLED" "$CONFIG_FILE_CORE"
-                setOption 'shard.method' "${SHARD_METHOD:-DB_ID}" "$CONFIG_FILE_CORE"
-                setOption 'shard.count' "$NUM_SHARDS" "$CONFIG_FILE_CORE"
-                setOption 'shard.instance' "$i" "$CONFIG_FILE_CORE"
+             createCoreStatically "$coreAlfrescoName" "$newCore"
 
-                if [ $SHARD_METHOD = "DB_ID_RANGE" ]
-                then
-                    setOption 'shard.range' "${SHARD_RANGE:-'0-100000'}" "$CONFIG_FILE_CORE"
-                elif [ $SHARD_METHOD = "PROPERTY" ]
-                then
-                    setOption 'shard.key' "${SHARD_KEY:-cm:creator}" "$CONFIG_FILE_CORE"
-                fi
+             setOption 'alfresco.stores' "workspace://SpacesStore" "$CONFIG_FILE_CORE"
+             setOption 'enable.alfresco.tracking' "${ALFRESCO_ENABLE_TRACKING:-true}" "$CONFIG_FILE_CORE"
+             setOption 'alfresco.index.transformContent' "${ALFRESCO_INDEX_CONTENT:-true}" "$CONFIG_FILE_CORE"
+             setOption 'alfresco.corePoolSize' "${ALFRESCO_CORE_POOL_SIZE:-8}" "$CONFIG_FILE_CORE"
+             setOption 'alfresco.doPermissionChecks' "${ALFRESCO_DO_PERMISSION_CHECKS:-true}" "$CONFIG_FILE_CORE"
+             setOption 'solr.suggester.enabled' "$ALFRESCO_SOLR_SUGGESTER_ENABLED" "$CONFIG_FILE_CORE"
 
-                CONFIG_FILE_SOLR_SCHEMA=$newCore/conf/schema.xml
-                if [ $ALFRESCO_SOLR_SUGGESTER_ENABLED = true ]
-                then
-                    sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/\1/g' "$CONFIG_FILE_SOLR_SCHEMA"
-                else
-                    sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/<!--\1-->/g' "$CONFIG_FILE_SOLR_SCHEMA"
-                fi
-                if [ $ALFRESCO_SOLR_FACETABLE_CATEGORIES_ENABLED = true ]
-                then
-                    sed -i 's/\(.*<dynamicField.*name="\(category\|noderef\)@m_.*type="\)\(oldStandardAnalysis\)\(".*\)\(\/\)\(.*\)/\1identifier\4docValues="true" \/\6/g' "$CONFIG_FILE_SOLR_SCHEMA"
-                    sed -i 's/\(.*<dynamicField.*name="\(category\|noderef\)@s_.*type="\)\(oldStandardAnalysis\)\(".*\)\(sortMissingLast="true"\)\(.*\)/\1identifier\4docValues="true"\6/g' "$CONFIG_FILE_SOLR_SCHEMA"
-                fi
+             CONFIG_FILE_SOLR_SCHEMA=$newCore/conf/schema.xml
+             if [ $ALFRESCO_SOLR_SUGGESTER_ENABLED = true ]
+             then
+                 sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/\1/g' "$CONFIG_FILE_SOLR_SCHEMA"
+             else
+                 sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/<!--\1-->/g' "$CONFIG_FILE_SOLR_SCHEMA"
+             fi
+             if [ $ALFRESCO_SOLR_FACETABLE_CATEGORIES_ENABLED = true ]
+             then
+                 sed -i 's/\(.*<dynamicField.*name="\(category\|noderef\)@m_.*type="\)\(oldStandardAnalysis\)\(".*\)\(\/\)\(.*\)/\1identifier\4docValues="true" \/\6/g' "$CONFIG_FILE_SOLR_SCHEMA"
+                 sed -i 's/\(.*<dynamicField.*name="\(category\|noderef\)@s_.*type="\)\(oldStandardAnalysis\)\(".*\)\(sortMissingLast="true"\)\(.*\)/\1identifier\4docValues="true"\6/g' "$CONFIG_FILE_SOLR_SCHEMA"
+             fi
+	     
+             setGlobalOptions "$CONFIG_FILE_CORE" $coreAlfrescoName
 
-                setGlobalOptions "$CONFIG_FILE_CORE" alfresco
+             escapeFile "$CONFIG_FILE_CORE"
 
-                escapeFile "$CONFIG_FILE_CORE"
+             if [ $CUSTOM_SCHEMA = true ]
+             then
+                 echo "Will copy custom schema to shard $newCore/conf/schema.xml"
+                 cp "$SOLR_INSTALL_HOME/schema.xml" $newCore/conf/schema.xml
+             fi
+             if [ $CUSTOM_RESOURCES = true ]
+             then
+                 echo "Copying custom resources to shard $newCore/conf/custom_resources/"
+                 cp -r "$SOLR_INSTALL_HOME/custom_resources/" $newCore/conf/custom_resources/
+             fi
+          done
 
-                if [ $CUSTOM_SCHEMA = true ]
-                then
-                echo "Will copy custom schema to shard $newCore/conf/schema.xml"
-                cp "$SOLR_INSTALL_HOME/schema.xml" $newCore/conf/schema.xml
-                fi
-                if [ $CUSTOM_RESOURCES = true ]
-                then
-                echo "Copying custom resources to shard $newCore/conf/custom_resources/"
-                cp -r "$SOLR_INSTALL_HOME/custom_resources/" $newCore/conf/custom_resources/
-                fi
-            done
-	    else
-            createCoreStatically "alfresco" "alfresco" "$newCore"
-
-            setOption 'alfresco.stores' "workspace://SpacesStore" "$CONFIG_FILE_CORE"
-            setOption 'enable.alfresco.tracking' "${ALFRESCO_ENABLE_TRACKING:-true}" "$CONFIG_FILE_CORE"
-            setOption 'alfresco.index.transformContent' "${ALFRESCO_INDEX_CONTENT:-true}" "$CONFIG_FILE_CORE"
-            setOption 'alfresco.corePoolSize' "${ALFRESCO_CORE_POOL_SIZE:-8}" "$CONFIG_FILE_CORE"
-            setOption 'alfresco.doPermissionChecks' "${ALFRESCO_DO_PERMISSION_CHECKS:-true}" "$CONFIG_FILE_CORE"
-            setOption 'solr.suggester.enabled' "$ALFRESCO_SOLR_SUGGESTER_ENABLED" "$CONFIG_FILE_CORE"
-
-            CONFIG_FILE_SOLR_SCHEMA=$newCore/conf/schema.xml
-
-            if [ $ALFRESCO_SOLR_SUGGESTER_ENABLED = true ]
-            then
-                sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/\1/g' "$CONFIG_FILE_SOLR_SCHEMA"
-            else
-                sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/<!--\1-->/g' "$CONFIG_FILE_SOLR_SCHEMA"
-            fi
-
-            if [ $ALFRESCO_SOLR_FACETABLE_CATEGORIES_ENABLED = true ]
-            then
-                sed -i 's/\(.*<dynamicField.*name="\(category\|noderef\)@m_.*type="\)\(oldStandardAnalysis\)\(".*\)\(\/\)\(.*\)/\1identifier\4docValues="true" \/\6/g' "$CONFIG_FILE_SOLR_SCHEMA"
-                sed -i 's/\(.*<dynamicField.*name="\(category\|noderef\)@s_.*type="\)\(oldStandardAnalysis\)\(".*\)\(sortMissingLast="true"\)\(.*\)/\1identifier\4docValues="true"\6/g' "$CONFIG_FILE_SOLR_SCHEMA"
-            fi
-
-            setGlobalOptions "$CONFIG_FILE_CORE" alfresco
-            escapeFile "$CONFIG_FILE_CORE"
-
-            if [ $CUSTOM_SCHEMA = true ]
-            then
-                echo "Will copy custom schema to $newCore/conf/schema.xml"
-                cp "$SOLR_INSTALL_HOME/schema.xml" $newCore/conf/schema.xml
-            fi
-            if [ $CUSTOM_RESOURCES = true ]
-            then
-                echo "Copying custom resources to shard $newCore/conf/custom_resources/"
-                cp -r "$SOLR_INSTALL_HOME/custom_resources/" $newCore/conf/custom_resources/
-            fi
-        fi
     elif [ $coreName = archive ]
     then
-        createCoreStatically "archive" "archive" "$newCore"
+        createCoreStatically "archive" "$newCore"
 
         setOption 'alfresco.stores' "archive://SpacesStore" "$CONFIG_FILE_CORE"
         setOption 'enable.alfresco.tracking' "${ARCHIVE_ENABLE_TRACKING:-true}" "$CONFIG_FILE_CORE"
@@ -258,7 +191,7 @@ function makeConfigs {
         fi
     elif [ $coreName = version ]
     then
-        createCoreStatically "version" "version" "$newCore"
+        createCoreStatically "version" "$newCore"
 
         setOption 'alfresco.stores' "workspace://version2Store" "$CONFIG_FILE_CORE"
 
@@ -309,27 +242,15 @@ makeConfigs
 
 user="solr"
 # make sure backup folders exist and have the right permissions in case of mounts
-if [ $SHARDING = true ]
-then
-    for i in $(echo $SHARD_IDS | tr "," "\n")
-    do
-        solrCoreName=alfresco-$i
-        mkdir -p "${DIR_ROOT}/solr6Backup/$solrCoreName"
-        if [[ $(stat -c %U "${DIR_ROOT}/solr6Backup/$solrCoreName") != "$user" ]]
-        then
-            chown -hR "$user":"$user" "${DIR_ROOT}/solr6Backup/$solrCoreName"
-        fi
-    done
-else
-    for solrCoreName in alfresco archive
-    do
-        mkdir -p "${DIR_ROOT}/solr6Backup/$solrCoreName"
-        if [[ $(stat -c %U "${DIR_ROOT}/solr6Backup/$solrCoreName") != "$user" ]]
-        then
-            chown -hR "$user":"$user" "${DIR_ROOT}/solr6Backup/$solrCoreName"
-        fi
-    done
-fi
+for coreName in in "${DEFAULT_CORES[@]}"
+do
+    mkdir -p "${DIR_ROOT}/solr6Backup/$coreName"
+    if [[ $(stat -c %U "${DIR_ROOT}/solr6Backup/$coreName") != "$user" ]]
+    then
+        chown -hR "$user":"$user" "${DIR_ROOT}/solr6Backup/$coreName"
+    fi
+done
+
 
 # fix permissions for whole data folder in case of mounts
 if [[ $(stat -c %U "${SOLR_DATA_ROOT}") != "$user" ]]

--- a/solr6/local/92-init-solr.sh
+++ b/solr6/local/92-init-solr.sh
@@ -116,7 +116,18 @@ function createCoreStatically {
 }
 
 function makeConfigs {
+    SHARED_PROPERTIES=${SOLR_DIR_ROOT}/conf/shared.properties
+    setOption 'solr.host' "$SOLR_HOST" "$SHARED_PROPERTIES"
+    setOption 'solr.port' "$PORT" "$SHARED_PROPERTIES"
 
+    if [ $ALFRESCO_SOLR_SUGGESTER_ENABLED = true ]
+    then
+	setOption 'alfresco.suggestable.property.0' '{http://www.alfresco.org/model/content/1.0}name' "$SHARED_PROPERTIES"
+	setOption 'alfresco.suggestable.property.1' '{http://www.alfresco.org/model/content/1.0}title' "$SHARED_PROPERTIES"
+	setOption 'alfresco.suggestable.property.2' '{http://www.alfresco.org/model/content/1.0}description' "$SHARED_PROPERTIES"
+	setOption 'alfresco.suggestable.property.3' '{http://www.alfresco.org/model/content/1.0}content' "$SHARED_PROPERTIES"
+    fi
+    
     for coreName in "${DEFAULT_CORES[@]}"
     do
 	newCore=${SOLR_DIR_ROOT}/$coreName
@@ -124,7 +135,6 @@ function makeConfigs {
 
 	if [ $coreName = alfresco ]
 	then
-	    SHARED_PROPERTIES=${SOLR_DIR_ROOT}/conf/shared.properties
 	    # for sharding - dynamic registration of shards
 	    if [ $SHARDING = true ]
 	    then
@@ -163,10 +173,6 @@ function makeConfigs {
                 if [ $ALFRESCO_SOLR_SUGGESTER_ENABLED = true ]
                 then
                     sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/\1/g' "$CONFIG_FILE_SOLR_SCHEMA"
-                    setOption 'alfresco.suggestable.property.0' '{http://www.alfresco.org/model/content/1.0}name' "$SHARED_PROPERTIES"
-                    setOption 'alfresco.suggestable.property.1' '{http://www.alfresco.org/model/content/1.0}title' "$SHARED_PROPERTIES"
-                    setOption 'alfresco.suggestable.property.2' '{http://www.alfresco.org/model/content/1.0}description' "$SHARED_PROPERTIES"
-                    setOption 'alfresco.suggestable.property.3' '{http://www.alfresco.org/model/content/1.0}content' "$SHARED_PROPERTIES"
                 else
                     sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/<!--\1-->/g' "$CONFIG_FILE_SOLR_SCHEMA"
                 fi
@@ -177,9 +183,6 @@ function makeConfigs {
                 fi
 
                 setGlobalOptions "$CONFIG_FILE_CORE" alfresco
-
-                setOption 'solr.host' "$SOLR_HOST" "$SHARED_PROPERTIES"
-                setOption 'solr.port' "$PORT" "$SHARED_PROPERTIES"
 
                 escapeFile "$CONFIG_FILE_CORE"
 
@@ -209,10 +212,6 @@ function makeConfigs {
             if [ $ALFRESCO_SOLR_SUGGESTER_ENABLED = true ]
             then
                 sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/\1/g' "$CONFIG_FILE_SOLR_SCHEMA"
-                setOption 'alfresco.suggestable.property.0' '{http://www.alfresco.org/model/content/1.0}name' "$SHARED_PROPERTIES"
-                setOption 'alfresco.suggestable.property.1' '{http://www.alfresco.org/model/content/1.0}title' "$SHARED_PROPERTIES"
-                setOption 'alfresco.suggestable.property.2' '{http://www.alfresco.org/model/content/1.0}description' "$SHARED_PROPERTIES"
-                setOption 'alfresco.suggestable.property.3' '{http://www.alfresco.org/model/content/1.0}content' "$SHARED_PROPERTIES"
             else
                 sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/<!--\1-->/g' "$CONFIG_FILE_SOLR_SCHEMA"
             fi

--- a/solr6/local/92-init-solr.sh
+++ b/solr6/local/92-init-solr.sh
@@ -43,7 +43,7 @@ function setOption {
     if grep --quiet -e "$1\s*=" "$3"; then
         # replace option
         sed -i "s#^\($1\s*=\s*\).*\$#\1$2#" $3
-	sed -i "s#^\#\($1\s*=\s*\).*\$#\1$2#" $3
+	    sed -i "s#^\#\($1\s*=\s*\).*\$#\1$2#" $3
         if (( $? )); then
             echo "setOption failed (replacing option $1=$2 in $3)"
             exit 1
@@ -63,13 +63,13 @@ function setGlobalOptions {
     IFS=$'\n'
     for i in `env`
     do
-	envCoreName=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 2`
-	if [[ $envCoreName = $coreName ]] || [[ $envCoreName = "ALL" ]] || [[ $envCoreName = "WORKSPACE" && $coreName =~ alfresco ]]
-	then
+	    envCoreName=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 2`
+	    if [[ $envCoreName = $coreName ]] || [[ $envCoreName = "ALL" ]] || [[ $envCoreName = "WORKSPACE" && $coreName =~ alfresco ]]
+	    then
             key=`echo $i | cut -d '=' -f 1 | cut -d '_' -f 3-`
             value=`echo $i | cut -d '=' -f 2-`
             setOption $key $value "$file"
-	fi
+	    fi
     done
 }
 
@@ -106,110 +106,109 @@ function makeConfigs {
     
     if [ $ALFRESCO_SOLR_SUGGESTER_ENABLED = true ]
     then
-	setOption 'alfresco.suggestable.property.0' '{http://www.alfresco.org/model/content/1.0}name' "$SHARED_PROPERTIES"
-	setOption 'alfresco.suggestable.property.1' '{http://www.alfresco.org/model/content/1.0}title' "$SHARED_PROPERTIES"
-	setOption 'alfresco.suggestable.property.2' '{http://www.alfresco.org/model/content/1.0}description' "$SHARED_PROPERTIES"
-	setOption 'alfresco.suggestable.property.3' '{http://www.alfresco.org/model/content/1.0}content' "$SHARED_PROPERTIES"
+        setOption 'alfresco.suggestable.property.0' '{http://www.alfresco.org/model/content/1.0}name' "$SHARED_PROPERTIES"
+        setOption 'alfresco.suggestable.property.1' '{http://www.alfresco.org/model/content/1.0}title' "$SHARED_PROPERTIES"
+        setOption 'alfresco.suggestable.property.2' '{http://www.alfresco.org/model/content/1.0}description' "$SHARED_PROPERTIES"
+        setOption 'alfresco.suggestable.property.3' '{http://www.alfresco.org/model/content/1.0}content' "$SHARED_PROPERTIES"
     fi
     
     for coreName in "${DEFAULT_CORES[@]}"
     do
-	newCore=${SOLR_DIR_ROOT}/$coreName
-	CONFIG_FILE_CORE=$newCore/conf/solrcore.properties
+	    newCore=${SOLR_DIR_ROOT}/$coreName
+	    CONFIG_FILE_CORE=$newCore/conf/solrcore.properties
 	
-	if [ $coreName = alfresco ]
-	then
+        if [ $coreName = alfresco ]
+        then
             for coreAlfrescoName in "${DEFAULT_CORES_ALFRESCO[@]}"
-	    do
-		# only use a collection in the case of a real sharded setup
-		if [ $coreAlfrescoName != $coreName ]
-		then
-		    collectionName=${TEMPLATE}-alfresco
-		    mkdir -p ${SOLR_DIR_ROOT}/$collectionName
-		    newCore=${SOLR_DIR_ROOT}/$collectionName/$coreAlfrescoName
-		fi
-		
-		CONFIG_FILE_CORE=$newCore/conf/solrcore.properties
-		
-		createCoreStatically "$coreAlfrescoName" "$newCore"
-		
-		setOption 'alfresco.stores' "workspace://SpacesStore" "$CONFIG_FILE_CORE"
-		setOption 'enable.alfresco.tracking' "${ALFRESCO_ENABLE_TRACKING:-true}" "$CONFIG_FILE_CORE"
-		setOption 'alfresco.index.transformContent' "${ALFRESCO_INDEX_CONTENT:-true}" "$CONFIG_FILE_CORE"
-		setOption 'alfresco.corePoolSize' "${ALFRESCO_CORE_POOL_SIZE:-8}" "$CONFIG_FILE_CORE"
-		setOption 'alfresco.doPermissionChecks' "${ALFRESCO_DO_PERMISSION_CHECKS:-true}" "$CONFIG_FILE_CORE"
-		setOption 'solr.suggester.enabled' "$ALFRESCO_SOLR_SUGGESTER_ENABLED" "$CONFIG_FILE_CORE"
-		
-		CONFIG_FILE_SOLR_SCHEMA=$newCore/conf/schema.xml
-		if [ $ALFRESCO_SOLR_SUGGESTER_ENABLED = true ]
-		then
+            do
+                # only use a collection in the case of a real sharded setup
+                if [ $coreAlfrescoName != $coreName ]
+                then
+                    collectionName=${TEMPLATE}-alfresco
+                    mkdir -p ${SOLR_DIR_ROOT}/$collectionName
+                    newCore=${SOLR_DIR_ROOT}/$collectionName/$coreAlfrescoName
+                fi
+
+                CONFIG_FILE_CORE=$newCore/conf/solrcore.properties
+
+                createCoreStatically "$coreAlfrescoName" "$newCore"
+
+                setOption 'alfresco.stores' "workspace://SpacesStore" "$CONFIG_FILE_CORE"
+                setOption 'enable.alfresco.tracking' "${ALFRESCO_ENABLE_TRACKING:-true}" "$CONFIG_FILE_CORE"
+                setOption 'alfresco.index.transformContent' "${ALFRESCO_INDEX_CONTENT:-true}" "$CONFIG_FILE_CORE"
+                setOption 'alfresco.corePoolSize' "${ALFRESCO_CORE_POOL_SIZE:-8}" "$CONFIG_FILE_CORE"
+                setOption 'alfresco.doPermissionChecks' "${ALFRESCO_DO_PERMISSION_CHECKS:-true}" "$CONFIG_FILE_CORE"
+                setOption 'solr.suggester.enabled' "$ALFRESCO_SOLR_SUGGESTER_ENABLED" "$CONFIG_FILE_CORE"
+
+                CONFIG_FILE_SOLR_SCHEMA=$newCore/conf/schema.xml
+                if [ $ALFRESCO_SOLR_SUGGESTER_ENABLED = true ]
+                then
                     sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/\1/g' "$CONFIG_FILE_SOLR_SCHEMA"
-		else
+                else
                     sed -i 's/.*\(<copyField source="suggest_\*" dest="suggest" \/>\).*/<!--\1-->/g' "$CONFIG_FILE_SOLR_SCHEMA"
-		fi
-		if [ $ALFRESCO_SOLR_FACETABLE_CATEGORIES_ENABLED = true ]
-		then
+                fi
+                if [ $ALFRESCO_SOLR_FACETABLE_CATEGORIES_ENABLED = true ]
+                then
                     sed -i 's/\(.*<dynamicField.*name="\(category\|noderef\)@m_.*type="\)\(oldStandardAnalysis\)\(".*\)\(\/\)\(.*\)/\1identifier\4docValues="true" \/\6/g' "$CONFIG_FILE_SOLR_SCHEMA"
                     sed -i 's/\(.*<dynamicField.*name="\(category\|noderef\)@s_.*type="\)\(oldStandardAnalysis\)\(".*\)\(sortMissingLast="true"\)\(.*\)/\1identifier\4docValues="true"\6/g' "$CONFIG_FILE_SOLR_SCHEMA"
-		fi
-		
-		setGlobalOptions "$CONFIG_FILE_CORE" $coreAlfrescoName
-		
-		escapeFile "$CONFIG_FILE_CORE"
-		
-		if [ $CUSTOM_SCHEMA = true ]
-		then
+                fi
+
+                setGlobalOptions "$CONFIG_FILE_CORE" $coreAlfrescoName
+
+                escapeFile "$CONFIG_FILE_CORE"
+
+                if [ $CUSTOM_SCHEMA = true ]
+                then
                     echo "Will copy custom schema to shard $newCore/conf/schema.xml"
                     cp "$SOLR_INSTALL_HOME/schema.xml" $newCore/conf/schema.xml
-		fi
-		if [ $CUSTOM_RESOURCES = true ]
-		then
+                fi
+                if [ $CUSTOM_RESOURCES = true ]
+                then
                     echo "Copying custom resources to shard $newCore/conf/custom_resources/"
                     cp -r "$SOLR_INSTALL_HOME/custom_resources/" $newCore/conf/custom_resources/
-		fi
+                fi
             done
-	    
-	elif [ $coreName = archive ]
-	then
+        elif [ $coreName = archive ]
+        then
             createCoreStatically "archive" "$newCore"
-	    
+
             setOption 'alfresco.stores' "archive://SpacesStore" "$CONFIG_FILE_CORE"
             setOption 'enable.alfresco.tracking' "${ARCHIVE_ENABLE_TRACKING:-true}" "$CONFIG_FILE_CORE"
             setOption 'alfresco.index.transformContent' "${ARCHIVE_INDEX_CONTENT:-true}" "$CONFIG_FILE_CORE"
-	    
+
             setGlobalOptions "$CONFIG_FILE_CORE" archive
             escapeFile "$CONFIG_FILE_CORE"
-	    
+
             if [ $CUSTOM_SCHEMA = true ]
             then
-		cp "$SOLR_INSTALL_HOME/schema.xml" $newCore/conf/schema.xml
+                cp "$SOLR_INSTALL_HOME/schema.xml" $newCore/conf/schema.xml
             fi
             if [ $CUSTOM_RESOURCES = true ]
             then
-		echo "Copying custom resources to shard $newCore/conf/custom_resources/"
-		cp -r "$SOLR_INSTALL_HOME/custom_resources/" $newCore/conf/custom_resources/
+                echo "Copying custom resources to shard $newCore/conf/custom_resources/"
+                cp -r "$SOLR_INSTALL_HOME/custom_resources/" $newCore/conf/custom_resources/
             fi
-	elif [ $coreName = version ]
-	then
+        elif [ $coreName = version ]
+        then
             createCoreStatically "version" "$newCore"
-	    
+
             setOption 'alfresco.stores' "workspace://version2Store" "$CONFIG_FILE_CORE"
-	    
+
             setGlobalOptions "$CONFIG_FILE_CORE" version
             escapeFile "$CONFIG_FILE_CORE"
-	    
+
             if [ $CUSTOM_SCHEMA = true ]
             then
-		cp "$SOLR_INSTALL_HOME/schema.xml" $newCore/conf/schema.xml
+                cp "$SOLR_INSTALL_HOME/schema.xml" $newCore/conf/schema.xml
             fi
             if [ $CUSTOM_RESOURCES = true ]
             then
-		echo "Copying custom resources to shard $newCore/conf/custom_resources/"
-		cp -r "$SOLR_INSTALL_HOME/custom_resources/" $newCore/conf/custom_resources/
+                echo "Copying custom resources to shard $newCore/conf/custom_resources/"
+                cp -r "$SOLR_INSTALL_HOME/custom_resources/" $newCore/conf/custom_resources/
             fi
-	else
+        else
             "Core $coreName not found"
-	fi
+        fi
     done
 }
 

--- a/src/integrationTest/resources/docker-compose-solr-sharded.yml
+++ b/src/integrationTest/resources/docker-compose-solr-sharded.yml
@@ -14,14 +14,11 @@ services:
     - ARCHIVE_INDEX_CONTENT=false
     - ALFRESCO_INDEX_CONTENT=false
     - MAX_HTTP_HEADER_SIZE=65536
-    - SHARDING=true
-    - SHARD_IDS=0,1
-    - SHARD_METHOD=DB_ID    
-    - CORE_NAME=alfresco    
-    - NUM_SHARDS=3
-    - NUM_NODES=2
-    - NODE_INSTANCE=1
-    - TEMPLATE=rerank
+    - CORES_ALFRESCO=alfresco-0;alfresco-1
+    - GLOBAL_ALL_shard.method=DB_ID
+    - GLOBAL_ALL_shard.count=3
+    - GLOBAL_alfresco-0_shard.instance=0
+    - GLOBAL_alfresco-1_shard.instance=1
 
   solr2:
     image: ${DOCKER_IMAGE}
@@ -36,11 +33,7 @@ services:
     - ARCHIVE_INDEX_CONTENT=false
     - ALFRESCO_INDEX_CONTENT=false
     - MAX_HTTP_HEADER_SIZE=65536
-    - SHARDING=true
-    - SHARD_IDS=2
-    - SHARD_METHOD=DB_ID    
-    - CORE_NAME=alfresco
-    - NUM_SHARDS=3
-    - NUM_NODES=2
-    - NODE_INSTANCE=2
-    - TEMPLATE=rerank
+    - CORES_ALFRESCO=alfresco-2
+    - GLOBAL_ALL_shard.method=DB_ID
+    - GLOBAL_ALL_shard.count=3    
+    - GLOBAL_alfresco-2_shard.instance=2


### PR DESCRIPTION
Currently the init script of solr6 does not allow easily to integrate method DB_ID_RANGE.
Sharded and non-sharded setup contain code duplication which can be avoided.

The whole block to create cores (shards or alfresco/archive) can be simplified and shard-specific variables can use the mechanism GLOBAL_<core>_<variable> to make it more generic.

Example of working setup (from integrationTest/resources/docker-compose-solr-sharded.yml):

    - CORES_ALFRESCO=alfresco-0;alfresco-1
    - GLOBAL_ALL_shard.method=DB_ID
    - GLOBAL_ALL_shard.count=3
    - GLOBAL_alfresco-0_shard.instance=0
    - GLOBAL_alfresco-1_shard.instance=1

Disabled code for sharding in solr4.