### PR TITLE
ALFREDAPI-482 add cross-locale property for consistent behaviour

### DIFF
--- a/upstream/solr6/local/92-init-solr.sh
+++ b/upstream/solr6/local/92-init-solr.sh
@@ -110,6 +110,9 @@ function makeConfigs {
         setOption 'alfresco.suggestable.property.3' '{http://www.alfresco.org/model/content/1.0}content' "$SHARED_PROPERTIES"
     fi
 
+    # Setting cross locale property for consistent behaviour with older versions ( =< 1.4.0)
+    setOption 'alfresco.cross.locale.property.2' '{http://www.alfresco.org/model/content/1.0}description' "$SHARED_PROPERTIES"
+
     # Load envvars starting with SHARED_ and put them in shared.properties
     for i in $(env)
     do


### PR DESCRIPTION
Apix integration tests point to a difference in configuration between 1.4.0 and 2.0.1.
Running `eu.xenit.apix.tests.search.SearchServiceFacetsTest` fails against 2.0.1 with the following error:
```
2021-06-11 13:43:20.138 ERROR (qtp1008315045-97) [   x:alfresco] o.a.s.s.HttpSolrCall null:java.lang.UnsupportedOperationException: Exact Term search is not supported unless you configure the field <{http://www.alfresco.org/model/content/1.0}description> for cross locale search
```
Change adds the property from the error to the `shared/properties` file.