### PR TITLE
DOCKER-407 set solr socket timeout param to unlimited wait

### DIFF
--- a/src/integrationTest/resources/docker-compose-alfresco.yml
+++ b/src/integrationTest/resources/docker-compose-alfresco.yml
@@ -1,14 +1,16 @@
 version: '3'
 
 services:
- alfresco:
-   image: ${ALFRESCO_IMAGE}
-   ports:
-   - 8080
-   restart: unless-stopped
-   environment:
-   - INDEX
-   - GLOBAL_legacy.transform.service.enabled=false
-   - GLOBAL_local.transform.service.enabled=false
-   - GLOBAL_transform.service.enabled=false
-
+  alfresco:
+    image: ${ALFRESCO_IMAGE}
+    ports:
+    - 8080
+    # - 8000:8000
+    restart: unless-stopped
+    environment:
+    # - DEBUG=true
+    - INDEX
+    - GLOBAL_legacy.transform.service.enabled=false
+    - GLOBAL_local.transform.service.enabled=false
+    - GLOBAL_transform.service.enabled=false
+    - GLOBAL_solr.http.socket.timeout=0

--- a/src/integrationTest/resources/docker-compose-solr.yml
+++ b/src/integrationTest/resources/docker-compose-solr.yml
@@ -1,15 +1,15 @@
 version: '3'
 
 services:
- solr:
-   image: ${DOCKER_IMAGE}
-   restart: unless-stopped
-   ports:
-   - 8443
-   #   - 8000:8000
-   #   - 5000:5000
-   environment:
-   #   - JMX_ENABLED=true
-   #   - DEBUG=true
-   - GLOBAL_WORKSPACE_solr.suggester.minSecsBetweenBuilds=3
-   # for restoring from backup, check non-ssl variant
+  solr:
+    image: ${DOCKER_IMAGE}
+    restart: unless-stopped
+    ports:
+    - 8443
+#    - 8000:8000
+#    - 5000:5000
+    environment:
+#    - JMX_ENABLED=true
+#    - DEBUG=true
+    - GLOBAL_WORKSPACE_solr.suggester.minSecsBetweenBuilds=3
+    # for restoring from backup, check non-ssl variant

--- a/upstream/solr6/alfresco-search-services-enterprise-2.0.2/overload.gradle
+++ b/upstream/solr6/alfresco-search-services-enterprise-2.0.2/overload.gradle
@@ -8,9 +8,7 @@ ext {
             ],
             flavor: 'solr6'
     ]
-// default integrationTests (using SSL) is failing when using ACS >= 6.2.1, fallback to 6.2.0
-//    alfrescoimage ='hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2'
-    alfrescoimage ='hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.0'
+    alfrescoimage ='hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2'
     tests = true
 }
 dependencies {

--- a/upstream/solr6/local/91-healthcheck.sh
+++ b/upstream/solr6/local/91-healthcheck.sh
@@ -28,7 +28,16 @@ then
     # this only works because images use the same keystore for alfresco and solr
     if [ ! -f "${SOLR_DIR_ROOT}/keystore/browser.pem" ]
     then
-	    keytool -importkeystore -srckeystore "${SOLR_DIR_ROOT}/keystore/${SSL_KEY_STORE}" -srcstorepass ${SSL_KEY_STORE_PASSWORD} -srcstoretype JCEKS -srcalias ${SSL_KEY_STORE_ALIAS} -destkeystore  "${SOLR_DIR_ROOT}/keystore/browser.p12" -deststoretype pkcs12 -destalias ssl.repo -deststorepass alfresco -destkeypass alfresco
+	    keytool -importkeystore \
+	    -srckeystore "${SOLR_DIR_ROOT}/keystore/${SSL_KEY_STORE}" \
+	    -srcstorepass ${SSL_KEY_STORE_PASSWORD} \
+	    -srcstoretype JCEKS \
+	    -srcalias ${SSL_KEY_STORE_ALIAS} \
+	    -destkeystore  "${SOLR_DIR_ROOT}/keystore/browser.p12" \
+	    -deststoretype pkcs12 \
+	    -destalias ssl.repo \
+	    -deststorepass alfresco \
+	    -destkeypass alfresco
 	    openssl pkcs12 -in "${SOLR_DIR_ROOT}/keystore/browser.p12" -out "${SOLR_DIR_ROOT}/keystore/browser.pem" -nodes -passin pass:alfresco
     fi
     echo "status=\$(curl -f -k -L -w %{http_code} -s -E ${SOLR_DIR_ROOT}/keystore/browser.pem -o /dev/null https://localhost:${PORT}/solr/${DEFAULT_CORES_ALFRESCO[0]}/admin/ping)" >>${SOLR_INSTALL_HOME}/healthcheck.sh


### PR DESCRIPTION
AC 6.2.2 exposed additional parameters (& set new defaults for) the solr http clients used by alfresco, which included a socket timeout setting.

In the older versions, this param was effectively 0, which is interpreted as unlimited by the http client lib.
The new default is 2000 ms.

This change sets the param explicitly to 0.
