### PR TITLE
Group together rest-assured dependencies for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,12 @@
     "config:base",
     ":dependencyDashboard"
   ],
+  "packageRules": [
+    {
+      "matchDatasources":  ["maven"],
+      "matchPackageNames": [ "^.*rest-assured.*$" ],
+      "groupName": "Rest-Assured dependencies"
+    }
+  ],
   "pinDigests": true
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
   "packageRules": [
     {
       "matchDatasources":  ["maven"],
-      "matchPackageNames": [ "^.*rest-assured.*$" ],
+      "matchPackageNames": [ "^.*rest-assured:" ],
       "groupName": "Rest-Assured dependencies"
     }
   ],


### PR DESCRIPTION
These dependencies should be updated together or they won't work. This config should (hopefully) tell Renovate to make a single PR grouping dependency updates for both, so we don't have one PR failing CI and one passing.
