### PR TITLE
[XEN-3140]: Maintenance pass

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,13 @@
         "org.alfresco:alfresco-search-services"
       ],
       "enabled": false
+    },
+    {
+      "description": "This project deliberately builds images for solr v6, prevent renovate from updating to v10.x",
+      "matchPackageNames": [
+        "org.apache.solr:solr-core"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,14 @@
     "config:base",
     ":dependencyDashboard"
   ],
-  "pinDigests": true
+  "pinDigests": true,
+  "packageRules": [
+    {
+      "description": "Each upstream/solr6/* directory pins one deliberate ASS release; bumping it would silently change which version that image builds",
+      "matchPackageNames": [
+        "org.alfresco:alfresco-search-services"
+      ],
+      "enabled": false
+    }
+  ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       UPSTREAM_PROJECT: ':upstream:${{ matrix.version }}-${{ matrix.assetVersion }}'
       XENIT_PROJECT: ':xenit:${{ matrix.version }}-${{ matrix.assetVersion }}'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -81,7 +81,7 @@ jobs:
         version:
           - solr6
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
       - name: Login to docker repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,20 @@ jobs:
       matrix:
         version:
           - solr6
-        task:
-          - integrationTestDefault
-          - integrationTestSharded
-          - integrationTestShardedNonSsl
-          - integrationTestNonSsl
-          - integrationTestMounts
-          - integrationTestXenitEndpoints
+        # One runner per search-services version: every task for that version runs
+        # here, instead of one runner walking all versions for a single task.
+        assetVersion:
+          - alfresco-search-services-community-1.4.3.4
+          - alfresco-search-services-community-2.0.6
+          - alfresco-search-services-community-2.0.8.2
+          - alfresco-search-services-community-2.0.9.1
+          - alfresco-search-services-enterprise-1.4.3.4
+          - alfresco-search-services-enterprise-2.0.6
+          - alfresco-search-services-enterprise-2.0.8.2
+          - alfresco-search-services-enterprise-2.0.9.1
+    env:
+      UPSTREAM_PROJECT: ':upstream:${{ matrix.version }}-${{ matrix.assetVersion }}'
+      XENIT_PROJECT: ':xenit:${{ matrix.version }}-${{ matrix.assetVersion }}'
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
@@ -47,12 +54,22 @@ jobs:
           VERSIONS_TO_BUILD: ${{ matrix.version }}
         with:
           cache-read-only: false
-          arguments: ${{ matrix.task }} --info
+          # Single Gradle invocation so the upstream image is built once and reused
+          # by the xenit image. Tasks run sequentially, so the compose stacks (which
+          # share fixed container names) never overlap.
+          arguments: >-
+            ${{ env.UPSTREAM_PROJECT }}:integrationTestDefault
+            ${{ env.UPSTREAM_PROJECT }}:integrationTestSharded
+            ${{ env.UPSTREAM_PROJECT }}:integrationTestShardedNonSsl
+            ${{ env.UPSTREAM_PROJECT }}:integrationTestNonSsl
+            ${{ env.UPSTREAM_PROJECT }}:integrationTestMounts
+            ${{ env.XENIT_PROJECT }}:integrationTestXenitEndpoints
+            --info
       - name: Upload Artifact
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.task }}-result
+          name: ${{ matrix.version }}-${{ matrix.assetVersion }}-result
           path: /home/runner/work/**/build/reports
           retention-days: 2
   publish:

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ restAssuredVersion=5.5.7
 awaitablityVersion=4.3.0
 
 defaultIntegrationTest=**/SolrSmokeTests.class
-v2IntegrationTest=**/SolrBackupTest.class
+backupIntegrationTest=**/SolrBackupTest.class

--- a/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
+++ b/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
@@ -288,6 +288,15 @@ public class SolrBackupTest {
                 .extract()
                 .body() // Extract the whole body
                 .asString(); // as a simple string
+        awaitRestoreSuccess();
+    }
+
+    /**
+     * Polls restorestatus until the restore succeeds. Solr does not retry a restore it has already
+     * given up on, so a "failed" status ends the wait immediately rather than burning the full
+     * timeout on a verdict that will not change.
+     */
+    private void awaitRestoreSuccess() {
         long startTime = System.currentTimeMillis();
         await().atMost(180, TimeUnit.SECONDS)
                 .pollInterval(1, TimeUnit.SECONDS).until(() -> {
@@ -299,7 +308,13 @@ public class SolrBackupTest {
                             .statusCode(200)
                             .extract()
                             .path("restorestatus.status");
-                    System.out.println("elapsed = " + (System.currentTimeMillis() - startTime) + "with status= " + status);
+                    System.out.println("elapsed = " + (System.currentTimeMillis() - startTime) + " with status= " + status);
+                    if ("failed".equals(status)) {
+                        throw new AssertionError(
+                                "Restore reported status=failed after "
+                                        + (System.currentTimeMillis() - startTime)
+                                        + "ms; check the solr container log for the cause");
+                    }
                     return "success".equals(status);
                 });
     }
@@ -342,7 +357,6 @@ public class SolrBackupTest {
                     .build();
         }
 
-        System.out.println("Restore triggered, will wait maximum 3 minutes");
         given()
                 .spec(restoreRequestSpec)
                 .when()
@@ -350,20 +364,7 @@ public class SolrBackupTest {
                 .then()
                 .statusCode(200);
         System.out.println("Restore triggered, will wait maximum 3 minutes");
-        long startTime = System.currentTimeMillis();
-        await().atMost(180, TimeUnit.SECONDS)
-                .pollInterval(1, TimeUnit.SECONDS).until(() -> {
-                    String status = given()
-                            .spec(restoreStatusRequestSpec)
-                            .when()
-                            .get()
-                            .then()
-                            .statusCode(200)
-                            .extract()
-                            .path("restorestatus.status");
-                    System.out.println("elapsed = " + (System.currentTimeMillis() - startTime) + "with status= " + status);
-                    return "success".equals(status);
-                });
+        awaitRestoreSuccess();
     }
     @Test
     @Order(1)

--- a/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
+++ b/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
@@ -29,7 +29,9 @@ import java.io.FileInputStream;
 import java.security.*;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -425,6 +427,9 @@ public class SolrBackupTest {
         return matcher.find() ? matcher.group(1) : null;
     }
     private void triggerBackupAndWaitForCompletion(int count, RequestSpecification solrBackupRequestSpec) {
+        Map<String, Object> before = backupDetails();
+        Object previousSnapshot = before == null ? null : before.get("snapshotName");
+
         String status = given()
                 .spec(solrBackupRequestSpec)
                 .when()
@@ -439,17 +444,49 @@ public class SolrBackupTest {
         await().atMost(540, TimeUnit.SECONDS)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(() -> {
-                    Object backup = given()
-                            .spec(backupDetailsRequestSpec)
-                            .when()
-                            .get()
-                            .then()
-                            .statusCode(200)
-                            .extract()
-                            .path("details.backup");
-                    System.out.println("elapsed = " + (System.currentTimeMillis() - startTime));
-                    return backup != null;
+                    Map<String, Object> backup = backupDetails();
+                    if (backup == null) {
+                        return false;
+                    }
+                    Object snapshot = backup.get("snapshotName");
+                    Object backupStatus = backup.get("status");
+                    System.out.println("elapsed = " + (System.currentTimeMillis() - startTime)
+                            + " with status= " + backupStatus + " snapshot= " + snapshot);
+                    // details reports the most recent backup, which is still the previous one until
+                    // this trigger produces its own snapshot.
+                    if (previousSnapshot != null && previousSnapshot.equals(snapshot)) {
+                        return false;
+                    }
+                    if ("failed".equals(backupStatus)) {
+                        throw new AssertionError("Backup reported status=failed"
+                                + (backup.get("exception") == null ? "" : ": " + backup.get("exception"))
+                                + "; check the solr container log");
+                    }
+                    return "success".equals(backupStatus);
                 });
+    }
+
+    /**
+     * Solr serialises the backup details as a flat [key, value, key, value, ...] array, so the
+     * status is not reachable through a plain json path.
+     */
+    private Map<String, Object> backupDetails() {
+        List<Object> backup = given()
+                .spec(backupDetailsRequestSpec)
+                .when()
+                .get()
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("details.backup");
+        if (backup == null) {
+            return null;
+        }
+        Map<String, Object> fields = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < backup.size(); i += 2) {
+            fields.put(String.valueOf(backup.get(i)), backup.get(i + 1));
+        }
+        return fields;
     }
 
     private static AmazonS3 createInternalClient(

--- a/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
+++ b/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
@@ -18,6 +18,7 @@ import io.restassured.specification.RequestSpecification;
 import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -34,12 +35,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
-import static java.lang.Thread.sleep;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -294,50 +295,44 @@ public class SolrBackupTest {
      * that window, and is usually quicker than the fixed 30s sleep this replaces.
      */
     private static void waitForIndexReady() {
-        long deadline = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5);
-        int previous = -1;
-        int stableRounds = 0;
-        while (System.currentTimeMillis() < deadline) {
-            int docs = totalDocs();
-            stableRounds = (docs > 0 && docs == previous) ? stableRounds + 1 : 0;
-            previous = docs;
-            if (stableRounds >= 2) {
-                System.out.println("Index settled at " + docs + " docs");
-                return;
-            }
-            try {
-                sleep(5000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return;
-            }
+        AtomicInteger previous = new AtomicInteger(-1);
+        try {
+            await().atMost(5, TimeUnit.MINUTES)
+                    .pollInterval(2, TimeUnit.SECONDS)
+                    // during() keeps this true for the whole window, so the count has to stay put
+                    // rather than merely match one earlier sample.
+                    .during(10, TimeUnit.SECONDS)
+                    // the cores are not necessarily serving yet
+                    .ignoreExceptions()
+                    .until(() -> {
+                        int docs = totalDocs();
+                        return docs > 0 && docs == previous.getAndSet(docs);
+                    });
+            System.out.println("Index settled at " + previous.get() + " docs");
+        } catch (ConditionTimeoutException e) {
+            // Not fatal: a failed backup now reports itself, which beats guessing here.
+            System.out.println("Index still moving after 5 minutes (last count " + previous.get()
+                    + "), backing up anyway");
         }
-        // Not fatal: the backup assertions below report the real problem better than a bare timeout.
-        System.out.println("Index still moving after 5 minutes (last count " + previous + "), backing up anyway");
     }
 
     private static int totalDocs() {
-        try {
-            Map<String, Map<String, Object>> status = given()
-                    .spec(coreStatusSpec)
-                    .when()
-                    .get()
-                    .then()
-                    .statusCode(200)
-                    .extract()
-                    .path("status");
-            if (status == null) {
-                return 0;
-            }
-            return status.values().stream()
-                    .map(core -> (Map<String, Object>) core.get("index"))
-                    .filter(index -> index != null && index.get("numDocs") != null)
-                    .mapToInt(index -> ((Number) index.get("numDocs")).intValue())
-                    .sum();
-        } catch (Exception e) {
-            // the cores are not necessarily serving yet
+        Map<String, Map<String, Object>> status = given()
+                .spec(coreStatusSpec)
+                .when()
+                .get()
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("status");
+        if (status == null) {
             return 0;
         }
+        return status.values().stream()
+                .map(core -> (Map<String, Object>) core.get("index"))
+                .filter(index -> index != null && index.get("numDocs") != null)
+                .mapToInt(index -> ((Number) index.get("numDocs")).intValue())
+                .sum();
     }
 
     @Test

--- a/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
+++ b/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
@@ -20,8 +20,10 @@ import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.FileInputStream;
 import java.security.*;
@@ -39,6 +41,9 @@ import static java.lang.Thread.sleep;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+// Without this the @Order annotations below do nothing, and the restore tests run before the
+// backup that is supposed to feed them.
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SolrBackupTest {
     static AmazonS3 s3Client;
     static RequestSpecification specShardedSolr1;

--- a/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
+++ b/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
@@ -61,6 +61,10 @@ public class SolrBackupTest {
     static boolean use_ssl = false;
     static final String BUCKET = "bucket";
     static final String basePathSolrBackup = "solr/alfresco/replication";
+    // S3BackupRepository takes the bucket from S3_BUCKET_NAME and uses whatever follows s3:// as the
+    // key prefix verbatim, so spelling the bucket out here filed every snapshot under a stray
+    // "bucket/" key that nothing ever read back. Same triple-slash form as 93-restore-from-backup.sh.
+    static final String BACKUP_LOCATION = "s3:///opt/alfresco-search-services/data/solr6Backup/";
 
     private static KeyStore loadKeyStore(String path, char[] password, String storeType) {
         KeyStore keyStore;
@@ -208,7 +212,7 @@ public class SolrBackupTest {
                     .addParam("command", "backup")
                     .addParam("repository", "s3")
                     .addParam("numberToKeep", "2")
-                    .addParam("location", "s3://bucket/opt/alfresco-search-services/data/solr6Backup/")
+                    .addParam("location", BACKUP_LOCATION)
                     .addParam("wt", "json")
                     .build();
             backupDetailsRequestSpec = new RequestSpecBuilder()
@@ -224,7 +228,7 @@ public class SolrBackupTest {
                     .setBasePath(basePathSolrBackup)
                     .addParam("command", "restore")
                     .addParam("repository", "s3")
-                    .addParam("location", "s3://bucket/opt/alfresco-search-services/data/solr6Backup/")
+                    .addParam("location", BACKUP_LOCATION)
                     .addParam("name", "my-alfresco-backup-20251006")
                     .build();
             restoreStatusRequestSpec = new RequestSpecBuilder()
@@ -242,7 +246,7 @@ public class SolrBackupTest {
                     .addParam("command", "backup")
                     .addParam("repository", "s3")
                     .addParam("numberToKeep", "2")
-                    .addParam("location", "s3://bucket/opt/alfresco-search-services/data/solr6Backup/")
+                    .addParam("location", BACKUP_LOCATION)
                     .addParam("wt", "json")
                     .build();
             backupDetailsRequestSpec = new RequestSpecBuilder()
@@ -258,7 +262,7 @@ public class SolrBackupTest {
                     .setBasePath(basePathSolrBackup)
                     .addParam("command", "restore")
                     .addParam("repository", "s3")
-                    .addParam("location", "s3://bucket/opt/alfresco-search-services/data/solr6Backup/")
+                    .addParam("location", BACKUP_LOCATION)
                     .addParam("name", "my-alfresco-backup-20251006")
                     .build();
             restoreStatusRequestSpec = new RequestSpecBuilder()
@@ -347,7 +351,7 @@ public class SolrBackupTest {
                     .setBasePath(basePathSolrBackup)
                     .addParam("command", "restore")
                     .addParam("repository", "s3")
-                    .addParam("location", "s3://bucket/opt/alfresco-search-services/data/solr6Backup/")
+                    .addParam("location", BACKUP_LOCATION)
                     .addParam("name", lastSnapshotName)
                     .build();
         } else {
@@ -357,7 +361,7 @@ public class SolrBackupTest {
                     .setBasePath(basePathSolrBackup)
                     .addParam("command", "restore")
                     .addParam("repository", "s3")
-                    .addParam("location", "s3://bucket/opt/alfresco-search-services/data/solr6Backup/")
+                    .addParam("location", BACKUP_LOCATION)
                     .addParam("name", lastSnapshotName)
                     .build();
         }

--- a/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
+++ b/src/integrationTest/java/eu/xenit/docker/solr/test/SolrBackupTest.java
@@ -55,6 +55,7 @@ public class SolrBackupTest {
     static RequestSpecification restoreFixedSnapshotRequestSpec;
     static RequestSpecification restoreStatusRequestSpec;
     static RequestSpecification restoreRequestSpec;
+    static RequestSpecification coreStatusSpec;
     static String solr1;
     static String baseURIShardedSolr1;
     static String baseURISolr;
@@ -275,12 +276,67 @@ public class SolrBackupTest {
                     .addParam("wt", "json")
                     .build();
         }
-        // wait for solr to track
-        long sleepTime = 30000;
+        coreStatusSpec = new RequestSpecBuilder()
+                .setBaseUri(solr1 == null ? baseURISolr : baseURIShardedSolr1)
+                .setPort(solr1 == null ? solrPort : portShardedSolr1)
+                .setBasePath(basePathSolr)
+                .addParam("action", "STATUS")
+                .addParam("wt", "json")
+                .build();
+
+        waitForIndexReady();
+    }
+
+    /**
+     * Backing up while the trackers are still indexing races lucene: SnapShooter lists the index
+     * files, then a merge deletes one before the S3 copy reaches it and the snapshot dies with a
+     * NoSuchFileException. Waiting for the document count to stop moving keeps the backup out of
+     * that window, and is usually quicker than the fixed 30s sleep this replaces.
+     */
+    private static void waitForIndexReady() {
+        long deadline = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5);
+        int previous = -1;
+        int stableRounds = 0;
+        while (System.currentTimeMillis() < deadline) {
+            int docs = totalDocs();
+            stableRounds = (docs > 0 && docs == previous) ? stableRounds + 1 : 0;
+            previous = docs;
+            if (stableRounds >= 2) {
+                System.out.println("Index settled at " + docs + " docs");
+                return;
+            }
+            try {
+                sleep(5000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+        // Not fatal: the backup assertions below report the real problem better than a bare timeout.
+        System.out.println("Index still moving after 5 minutes (last count " + previous + "), backing up anyway");
+    }
+
+    private static int totalDocs() {
         try {
-            sleep(sleepTime);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
+            Map<String, Map<String, Object>> status = given()
+                    .spec(coreStatusSpec)
+                    .when()
+                    .get()
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .path("status");
+            if (status == null) {
+                return 0;
+            }
+            return status.values().stream()
+                    .map(core -> (Map<String, Object>) core.get("index"))
+                    .filter(index -> index != null && index.get("numDocs") != null)
+                    .mapToInt(index -> ((Number) index.get("numDocs")).intValue())
+                    .sum();
+        } catch (Exception e) {
+            // the cores are not necessarily serving yet
+            return 0;
         }
     }
 

--- a/src/integrationTest/java/eu/xenit/docker/solr/test/SolrSmokeTests.java
+++ b/src/integrationTest/java/eu/xenit/docker/solr/test/SolrSmokeTests.java
@@ -22,6 +22,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -216,6 +217,48 @@ public class SolrSmokeTests {
             // Deliberately not failing here: the assertions below report what is actually
             // missing, which beats a bare timeout.
             System.out.println("Timed out waiting for Solr to track content, running tests anyway.");
+            reportReadiness();
+        }
+    }
+
+    /**
+     * "Expected status code 200 but was 503" does not say which component is unhealthy, and by the
+     * time an assertion fails we no longer know which of the awaited conditions held. The readiness
+     * bodies usually name the culprit, so dump them once when the wait gives up.
+     */
+    private static void reportReadiness() {
+        System.out.println("  search hits: " + attempt(SolrSmokeTests::searchHits));
+        if (telemetry) {
+            System.out.println("  telemetry: " + probe(specTelemetry));
+        }
+        if (actuators) {
+            System.out.println("  actuators: " + probe(specActuators));
+        }
+        if (specShardedSolr1 != null) {
+            System.out.println("  alfresco-0 docs: " + attempt(() -> coreDocs(specShardedSolr1, "alfresco-0")));
+            System.out.println("  alfresco-1 docs: " + attempt(() -> coreDocs(specShardedSolr1, "alfresco-1")));
+            System.out.println("  alfresco-2 docs: " + attempt(() -> coreDocs(specShardedSolr2, "alfresco-2")));
+        }
+    }
+
+    private static String probe(RequestSpecification endpointSpec) {
+        try {
+            Response response = given().spec(endpointSpec).when().get();
+            String body = response.asString();
+            if (body != null && body.length() > 500) {
+                body = body.substring(0, 500) + " ...(truncated)";
+            }
+            return "HTTP " + response.statusCode() + " body=" + body;
+        } catch (Exception e) {
+            return "request failed: " + e;
+        }
+    }
+
+    private static String attempt(Supplier<Integer> value) {
+        try {
+            return String.valueOf(value.get());
+        } catch (Exception e) {
+            return "unavailable: " + e;
         }
     }
 

--- a/src/integrationTest/java/eu/xenit/docker/solr/test/SolrSmokeTests.java
+++ b/src/integrationTest/java/eu/xenit/docker/solr/test/SolrSmokeTests.java
@@ -12,20 +12,28 @@ import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import org.awaitility.core.ConditionTimeoutException;
+
 import java.io.FileInputStream;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
+import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.Thread.sleep;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SolrSmokeTests {
+
+    private static final String SEARCH_URL = "/api/-default-/public/search/versions/1/search";
+    // simple json, no need for an additional library
+    // templates don't work with afts, fields to search into need to be specified
+    private static final String SEARCH_BODY = "{ \"query\": { \"query\": \"cm:name:xml*\" } }";
 
     static RequestSpecification spec;
     static RequestSpecification specShardedSolr1;
@@ -189,72 +197,86 @@ public class SolrSmokeTests {
             System.out.println(
                     "baseURISolr=" + baseURISolr + " and solrPort=" + solrPort + " and path=" + basePathSolrActuators);
         }
-        // wait for solr to track
-        long sleepTime = 40000;
+        awaitTracking();
+    }
+
+    /**
+     * Solr tracks Alfresco in the background, so the smoke tests only become meaningful once the
+     * first content has been indexed.
+     */
+    private static void awaitTracking() {
         try {
-            sleep(sleepTime);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
+            await().atMost(5, TimeUnit.MINUTES)
+                    .pollInterval(2, TimeUnit.SECONDS)
+                    // tracking has not started yet, so the endpoints may still error out
+                    .ignoreExceptions()
+                    .until(SolrSmokeTests::isTracked);
+        } catch (ConditionTimeoutException e) {
+            // Deliberately not failing here: the assertions below report what is actually
+            // missing, which beats a bare timeout.
+            System.out.println("Timed out waiting for Solr to track content, running tests anyway.");
         }
+    }
+
+    private static boolean isTracked() {
+        if (searchHits() <= 0) {
+            return false;
+        }
+        if (specShardedSolr1 == null) {
+            return true;
+        }
+        return coreDocs(specShardedSolr1, "alfresco-0") > 50
+                && coreDocs(specShardedSolr1, "alfresco-1") > 50
+                && coreDocs(specShardedSolr2, "alfresco-2") > 50;
+    }
+
+    private static int searchHits() {
+        Object totalItems = given()
+                .spec(spec)
+                .when()
+                .header("Content-Type", "application/json")
+                .body(SEARCH_BODY)
+                .post(SEARCH_URL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("list.pagination.totalItems");
+
+        return totalItems == null ? 0 : Integer.parseInt(totalItems.toString());
+    }
+
+    private static int coreDocs(RequestSpecification solrSpec, String core) {
+        Integer docs = given()
+                .spec(solrSpec)
+                .contentType("application/json")
+                .when()
+                .get()
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().path("status." + core + ".index.numDocs");
+
+        // the core is absent from the status response until it has been created
+        return docs == null ? 0 : docs;
     }
 
     @Test
     public void testSearch() {
         String flavor = System.getProperty("flavor");
         System.out.println("flavor=" + flavor);
-        String response;
 
-        System.out.println("will use api call");
-        String urlSearch = "/api/-default-/public/search/versions/1/search";
-        // simple json, no need for an additional library
-        // templates don't work with afts, fields to search into need to be specified
-        String requestParams = "{ \"query\": { \"query\": \"cm:name:xml*\" } }";
-        response = given()
-                .spec(spec)
-                .when()
-                .header("Content-Type", "application/json")
-                .body(requestParams)
-                .post(urlSearch)
-                .then()
-                .statusCode(200)
-                .extract()
-                .path("list.pagination.totalItems")
-                .toString();
+        int totalItems = searchHits();
 
-        System.out.println("response=" + response);
-        assertTrue(Integer.parseInt(response) > 0, "Response list.pagination.totalItems > 0");
+        System.out.println("response=" + totalItems);
+        assertTrue(totalItems > 0, "Response list.pagination.totalItems > 0");
     }
 
     @Test
     public void TestShards() {
         if (specShardedSolr1 != null) {
-            Integer docs0 = given()
-                    .spec(specShardedSolr1)
-                    .contentType("application/json")
-                    .when()
-                    .get()
-                    .then()
-                    .statusCode(200)
-                    .contentType(JSON)
-                    .extract().path("status.alfresco-0.index.numDocs");
-            Integer docs1 = given()
-                    .spec(specShardedSolr1)
-                    .contentType("application/json")
-                    .when()
-                    .get()
-                    .then()
-                    .statusCode(200)
-                    .contentType(JSON)
-                    .extract().path("status.alfresco-1.index.numDocs");
-            Integer docs2 = given()
-                    .spec(specShardedSolr2)
-                    .contentType("application/json")
-                    .when()
-                    .get()
-                    .then()
-                    .statusCode(200)
-                    .contentType(JSON)
-                    .extract().path("status.alfresco-2.index.numDocs");
+            int docs0 = coreDocs(specShardedSolr1, "alfresco-0");
+            int docs1 = coreDocs(specShardedSolr1, "alfresco-1");
+            int docs2 = coreDocs(specShardedSolr2, "alfresco-2");
             assertTrue(docs0 > 50, "docs0 is greater than 50");
             assertTrue(docs1 > 50, "docs1 is greater than 50");
             assertTrue(docs2 > 50, "docs2 is greater than 50");

--- a/src/integrationTest/java/eu/xenit/docker/solr/test/SolrSmokeTests.java
+++ b/src/integrationTest/java/eu/xenit/docker/solr/test/SolrSmokeTests.java
@@ -6,6 +6,7 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SSLConfig;
 import io.restassured.parsing.Parser;
+import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
 import org.apache.http.conn.ssl.SSLSocketFactory;
@@ -222,12 +223,24 @@ public class SolrSmokeTests {
         if (searchHits() <= 0) {
             return false;
         }
+        // These lag behind tracking: solr answers searches before the readiness probe flips to UP.
+        if (telemetry && !endpointServes(specTelemetry, "alfresco_nodes")) {
+            return false;
+        }
+        if (actuators && !endpointServes(specActuators, "UP")) {
+            return false;
+        }
         if (specShardedSolr1 == null) {
             return true;
         }
         return coreDocs(specShardedSolr1, "alfresco-0") > 50
                 && coreDocs(specShardedSolr1, "alfresco-1") > 50
                 && coreDocs(specShardedSolr2, "alfresco-2") > 50;
+    }
+
+    private static boolean endpointServes(RequestSpecification endpointSpec, String expected) {
+        Response response = given().spec(endpointSpec).when().get();
+        return response.statusCode() == 200 && response.asString().contains(expected);
     }
 
     private static int searchHits() {

--- a/src/integrationTest/resources/aws/script.sh
+++ b/src/integrationTest/resources/aws/script.sh
@@ -2,5 +2,7 @@
 echo "--- Creating S3 bucket for Solr backups ---"
 awslocal s3 mb s3://bucket
 
-echo "--- Uploading Solr snapshot 'my-test-name-x' to S3 ---"
-awslocal s3 sync /backups/snapshot s3://bucket/opt/alfresco-search-services/data/solr6Backup/alfresco/snapshot.my-alfresco-backup-20251006
+# The key has to match what solr reads for location=s3:///opt/... , i.e. no core name in the path.
+# The previous "alfresco/" segment put the snapshot somewhere no restore ever looked.
+echo "--- Uploading Solr snapshot 'my-alfresco-backup-20251006' to S3 ---"
+awslocal s3 sync /backups/snapshot s3://bucket/opt/alfresco-search-services/data/solr6Backup/snapshot.my-alfresco-backup-20251006

--- a/src/integrationTest/resources/aws/script.sh
+++ b/src/integrationTest/resources/aws/script.sh
@@ -2,7 +2,17 @@
 echo "--- Creating S3 bucket for Solr backups ---"
 awslocal s3 mb s3://bucket
 
-# The key has to match what solr reads for location=s3:///opt/... , i.e. no core name in the path.
-# The previous "alfresco/" segment put the snapshot somewhere no restore ever looked.
-echo "--- Uploading Solr snapshot 'my-alfresco-backup-20251006' to S3 ---"
-awslocal s3 sync /backups/snapshot s3://bucket/opt/alfresco-search-services/data/solr6Backup/snapshot.my-alfresco-backup-20251006
+# The two search services generations resolve a backup location differently: 2.0.x appends the core
+# name, 1.4.x does not. Their solr logs show it plainly:
+#   2.0.8.2  //opt//alfresco-search-services//data//solr6Backup//alfresco
+#   1.4.3.4  //opt//alfresco-search-services//data//solr6Backup//
+# Rather than teach this script which version it is serving, seed both keys so either generation
+# finds the snapshot under the name the tests ask for.
+BASE=s3://bucket/opt/alfresco-search-services/data/solr6Backup
+SNAPSHOT=snapshot.my-alfresco-backup-20251006
+
+echo "--- Uploading Solr snapshot 'my-alfresco-backup-20251006' to S3 (1.4.x layout) ---"
+awslocal s3 sync /backups/snapshot "$BASE/$SNAPSHOT"
+
+echo "--- Uploading Solr snapshot 'my-alfresco-backup-20251006' to S3 (2.0.x layout, core in path) ---"
+awslocal s3 sync /backups/snapshot "$BASE/alfresco/$SNAPSHOT"

--- a/upstream/build.gradle
+++ b/upstream/build.gradle
@@ -188,12 +188,18 @@ subprojects {
         environment.put 'INDEX', project.solr.flavor
         environment.put 'use_ssl', true
 
+        // composeDown deletes the containers, so a CI step can never reach `docker logs` afterwards.
+        // Capture while they run, under build/reports so the existing artifact upload picks it up.
+        captureContainersOutputToFiles.set(project.layout.buildDirectory.dir("reports/container-logs/default"))
+
         isRequiredBy(project.tasks.integrationTestDefault)
 
         useComposeFiles = ["$composeDir/docker-compose-alfresco.yml", "$composeDir/docker-compose-solr.yml",
                            "$composeDir/docker-compose-db.yml", "$composeDir/docker-compose-localstack.yml"];
 
         sharded {
+            captureContainersOutputToFiles.set(project.layout.buildDirectory.dir("reports/container-logs/sharded"))
+
             isRequiredBy(project.tasks.integrationTestSharded)
 
             environment.put 'use_ssl', true
@@ -206,6 +212,8 @@ subprojects {
         }
 
         shardedNonSsl {
+            captureContainersOutputToFiles.set(project.layout.buildDirectory.dir("reports/container-logs/shardedNonSsl"))
+
             isRequiredBy(project.tasks.integrationTestShardedNonSsl)
 
             environment.put 'use_ssl', false
@@ -218,6 +226,8 @@ subprojects {
         }
 
         nonSsl {
+            captureContainersOutputToFiles.set(project.layout.buildDirectory.dir("reports/container-logs/nonSsl"))
+
             isRequiredBy(project.tasks.integrationTestNonSsl)
 
             environment.put 'use_ssl', false
@@ -227,6 +237,8 @@ subprojects {
         }
 
         mounts {
+            captureContainersOutputToFiles.set(project.layout.buildDirectory.dir("reports/container-logs/mounts"))
+
             isRequiredBy(project.tasks.integrationTestMounts)
 
             environment.put 'use_ssl', true

--- a/xenit/build.gradle
+++ b/xenit/build.gradle
@@ -149,6 +149,10 @@ subprojects {
         environment.put 'ALFRESCO_IMAGE', upstreamProject.alfrescoimage
         environment.put 'INDEX', upstreamProject.solr.flavor
 
+        // composeDown deletes the containers, so a CI step can never reach `docker logs` afterwards.
+        // Capture while they run, under build/reports so the existing artifact upload picks it up.
+        captureContainersOutputToFiles.set(project.layout.buildDirectory.dir("reports/container-logs"))
+
         isRequiredBy(project.tasks.integrationTestXenitEndpoints)
 
         useComposeFiles = composeFiles

--- a/xenit/build.gradle
+++ b/xenit/build.gradle
@@ -132,12 +132,7 @@ subprojects {
             systemProperty("keystore", "${rootProject.projectDir}/src/main/resources/global/keystore/ssl.repo.client.keystore")
             systemProperty("truststore", "${rootProject.projectDir}/src/main/resources/global/keystore/ssl.repo.client.truststore")
 
-            if (project.name.contains('enterprise') && project.name.contains('-2')) {
-                println("V2 logic applied to ${project.name}")
-                include(project.property('defaultIntegrationTest'), project.property('v2IntegrationTest'))
-            } else {
-                include(project.property('defaultIntegrationTest'))
-            }
+            include(project.property('defaultIntegrationTest'), project.property('backupIntegrationTest'))
         }
     }
 

--- a/xenit/solr6/alfresco-search-services-enterprise-1.4.3.4/overload.gradle
+++ b/xenit/solr6/alfresco-search-services-enterprise-1.4.3.4/overload.gradle
@@ -1,3 +1,8 @@
+ext {
+    // Absent until now, which left this the one xenit project that started a stack and then ran
+    // nothing, since the compose tasks run regardless of whether the test task is enabled.
+    tests = true
+}
 dependencies {
     telemetry group: 'eu.xenit.alfred.telemetry', name: 'alfred-telemetry-solr6', version: "${alfredTelemetryVersion}"
 }


### PR DESCRIPTION
- Speed up CI by parallelizing on version instead of on test.
- Update actions/checkout action to v7
- Prevent renovate from updating `alfresco-search-services` and `solr-core` dependencies.
- Avoid sleeping in integration tests while waiting for solr to track. Instead, just use Awaitilty (was already a dependency), to poll the endpoint until all documents are tracked.
- On test failure, dump container logs to uploaded artifact
- Fixes for `SolrBackupTest`:
    - Properly apply `@Order` annotations
    - Fail-fast if backup failed
    - Used Claude to further fix `SolrBackupTest`, it now applies to all configurations and is testing each test case properly, instead of only working for ASS 2.x and incorrectly passing some tests.
