### PR TITLE
[XEN-3140]: Use JDK 21 for running tests & gradle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,11 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '11'
+          # 11 for the code that ends up in the images, 21 for the integration tests.
+          # Gradle toolchains automatically pick the correct one.
+          java-version: |
+            11
+            21
       - name: install docker-compose
         run: sudo apt-get install docker-ce docker-compose
       - name: Add license
@@ -82,6 +86,12 @@ jobs:
           - solr6
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: |
+            11
+            21
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
       - name: Login to docker repo

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,18 @@ subprojects {
     tasks.withType(Test) {
         useJUnitPlatform()
     }
+
+    // Everything shipped into images needs to be java 11 (alfresco compatibility), but
+    // the integration tests themselves only do HTTP calls against these images, so they can be upgraded.
+    def integrationTestJava = JavaLanguageVersion.of(integrationTestJavaVersion as Integer)
+
+    tasks.named('compileIntegrationTestJava') {
+        javaCompiler = javaToolchains.compilerFor { languageVersion = integrationTestJava }
+    }
+
+    tasks.matching { it instanceof Test && it.name.startsWith('integrationTest') }.configureEach {
+        javaLauncher = javaToolchains.launcherFor { languageVersion = integrationTestJava }
+    }
     dependencies {
         backupJar project(path: ":solr-backup")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,9 @@ jaxBVersion=4.0.9
 restAssuredVersion=5.5.7
 awaitablityVersion=4.3.0
 
+integrationTestJavaVersion=21
+# Where setup-java parks the extra JDKs on GitHub Actions
+org.gradle.java.installations.fromEnv=JAVA_HOME_11_X64,JAVA_HOME_21_X64
+
 defaultIntegrationTest=**/SolrSmokeTests.class
 backupIntegrationTest=**/SolrBackupTest.class

--- a/solr-backup/build.gradle
+++ b/solr-backup/build.gradle
@@ -6,8 +6,10 @@ description = "Xenit backup"
 group = 'eu.xenit.solr-backup'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    // Runs inside built images, so this should be 11
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
     withJavadocJar()
     withSourcesJar()
 }


### PR DESCRIPTION
This updates the gradle and CI configurations to run the integration tests and gradle with JDK 21, while keeping the built images under JDK 11.

This allows updating some dependencies to newer major versions, and also allows upgrading to Gradle 9.