### PR TITLE
[XEN-3140]: Replace deprecated gradle-build-action with setup-gradle action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo '${{ secrets.HARBOR_PASSWORD }}' | docker login docker.xenit.eu --username '${{ secrets.HARBOR_USER }}' --password-stdin
       - name: Integration tests
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
         env:
           VERSIONS_TO_BUILD: ${{ matrix.version }}
         with:
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
       - name: Login to docker repo
         run: |
           echo '${{ secrets.HARBOR_PASSWORD }}' | docker login docker.xenit.eu --username '${{ secrets.HARBOR_USER }}' --password-stdin
@@ -91,7 +91,7 @@ jobs:
       # without supplying DOCKER_USER and DOCKER_PASSWORD. However, supplying those environment variables breaks
       # publishing to other repositories
       - name: Publish public docker images
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -100,7 +100,7 @@ jobs:
           cache-read-only: false
           arguments: pushDockerImage -PincludeEnterprise=false
       - name: Publish private docker images
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
         env:
           VERSIONS_TO_BUILD: ${{ matrix.version }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,22 +48,24 @@ jobs:
       - name: Login to Docker
         run: |
           echo '${{ secrets.HARBOR_PASSWORD }}' | docker login docker.xenit.eu --username '${{ secrets.HARBOR_USER }}' --password-stdin
-      - name: Integration tests
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-        env:
-          VERSIONS_TO_BUILD: ${{ matrix.version }}
         with:
           cache-read-only: false
-          # Single Gradle invocation so the upstream image is built once and reused
-          # by the xenit image. Tasks run sequentially, so the compose stacks (which
-          # share fixed container names) never overlap.
-          arguments: >-
-            ${{ env.UPSTREAM_PROJECT }}:integrationTestDefault
-            ${{ env.UPSTREAM_PROJECT }}:integrationTestSharded
-            ${{ env.UPSTREAM_PROJECT }}:integrationTestShardedNonSsl
-            ${{ env.UPSTREAM_PROJECT }}:integrationTestNonSsl
-            ${{ env.UPSTREAM_PROJECT }}:integrationTestMounts
-            ${{ env.XENIT_PROJECT }}:integrationTestXenitEndpoints
+      - name: Integration tests
+        env:
+          VERSIONS_TO_BUILD: ${{ matrix.version }}
+        # Single Gradle invocation so the upstream image is built once and reused
+        # by the xenit image. Tasks run sequentially, so the compose stacks (which
+        # share fixed container names) never overlap.
+        run: |
+          ./gradlew \
+            "${{ env.UPSTREAM_PROJECT }}:integrationTestDefault" \
+            "${{ env.UPSTREAM_PROJECT }}:integrationTestSharded" \
+            "${{ env.UPSTREAM_PROJECT }}:integrationTestShardedNonSsl" \
+            "${{ env.UPSTREAM_PROJECT }}:integrationTestNonSsl" \
+            "${{ env.UPSTREAM_PROJECT }}:integrationTestMounts" \
+            "${{ env.XENIT_PROJECT }}:integrationTestXenitEndpoints" \
             --info
       - name: Upload Artifact
         if: success() || failure()
@@ -84,6 +86,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: false
       - name: Login to docker repo
         run: |
           echo '${{ secrets.HARBOR_PASSWORD }}' | docker login docker.xenit.eu --username '${{ secrets.HARBOR_USER }}' --password-stdin
@@ -91,18 +95,12 @@ jobs:
       # without supplying DOCKER_USER and DOCKER_PASSWORD. However, supplying those environment variables breaks
       # publishing to other repositories
       - name: Publish public docker images
-        uses: gradle/actions/setup-gradle@v6
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           VERSIONS_TO_BUILD: ${{ matrix.version }}
-        with:
-          cache-read-only: false
-          arguments: pushDockerImage -PincludeEnterprise=false
+        run: ./gradlew pushDockerImage -PincludeEnterprise=false
       - name: Publish private docker images
-        uses: gradle/actions/setup-gradle@v6
         env:
           VERSIONS_TO_BUILD: ${{ matrix.version }}
-        with:
-          cache-read-only: false
-          arguments: pushDockerImage -PincludeCommunity=false
+        run: ./gradlew pushDockerImage -PincludeCommunity=false


### PR DESCRIPTION
`gradle/gradle-build-action@v3` is deprecated and is replaced with `gradle/actions/setup-gradle@v6`. This also removed support for the `arguments` parameter, the CI configuration now expects a separate `setup-gradle` step, the integration test step can be a simple `./gradlew` invocation (see the [upgrade guide](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)).